### PR TITLE
fix: ログイン前ヘッダーのリンク修正

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,15 +1,10 @@
 <header class="text-neutral-50 bg-yellow-400 body-font font-medium">
   <div class="flex flex-wrap p-5 flex-col md:flex-row items-center">
-    <a class="flex title-font items-center text-neutral-50 mb-4 md:mb-0">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10 text-amber p-2 rounded-full" viewBox="0 0 24 24">
-        <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
-      </svg>
-      <span class="ml-3 text-3xl">Music Map</span>
-    </a>
+    <%= link_to "Music Map", root_path, class: "flex title-font items-center text-3xl text-neutral-50 mb-4 md:mb-0 flex" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
-      <%= link_to "聖地一覧", "#", class: "mr-5 hover:font-semibold" %>
-      <%= link_to "マップ投稿検索", "#", class: "mr-5 hover:font-semibold" %>
-      <%= link_to "ログイン", "#", class: "mr-5 hover:font-semibold" %>
+      <%= link_to "聖地一覧", "#", class: "mr-5" %>
+      <%= link_to "マップ投稿検索", "#", class: "mr-5" %>
+      <%= link_to "ログイン", "#", class: "mr-5" %>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
ログイン前ヘッダーのリンクを`a`タグから`link_to`に変更しました。
また、`聖地一覧`、`マップ投稿検索`、`ログイン`の３つのリンクのhover状態のCSSを削除しました。