### PR TITLE
add: Spotify APIの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,9 @@ gem 'sorcery'
 
 # 画像アップロード
 gem "carrierwave"
+
+# 環境変数
+gem "dotenv-rails"
+
+# Spotify API
+gem "rspotify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,11 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
+    domain_name (0.6.20231109)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -123,6 +128,8 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -152,6 +159,9 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1205)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -168,6 +178,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
@@ -191,6 +202,13 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -209,6 +227,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (3.0.8)
+    rack-protection (3.0.6)
+      rack
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -252,8 +272,16 @@ GEM
     regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     rouge (4.2.0)
+    rspotify (2.12.0)
+      addressable (~> 2.8.0)
+      omniauth-oauth2 (>= 1.6)
+      rest-client (~> 2.0.2)
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -340,12 +368,14 @@ DEPENDENCIES
   bullet
   carrierwave
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.2)
+  rspotify
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,8 +1,9 @@
 class SpotsController < ApplicationController
   skip_before_action :require_login, only: %i[index]
+  before_action :check_artist_name, only: %i[create]
 
   def index
-    @spots = Spot.all
+    @spots = Spot.all.order(updated_at: "DESC")
   end
 
   def show; end
@@ -14,9 +15,13 @@ class SpotsController < ApplicationController
   # def edit; end
 
   def create
-    @spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
-    if @spot.save
-      redirect_to spots_path
+    if check_artist_name
+      @spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
+      if @spot.save
+        redirect_to spots_path
+      else
+        render :new
+      end
     else
       render :new
     end
@@ -34,5 +39,13 @@ class SpotsController < ApplicationController
 
   def spot_params
     params.require(:artist_spot).permit(:tag, :spot_name, :name, :detail)
+  end
+
+  # Spotify API上のデータと比較することで正確なアーティスト名が入力されているかチェックするメソッド
+  def check_artist_name
+    artist_name = params["artist_spot"]["name"]
+    spotify_data = RSpotify::Artist.search(artist_name).first
+    spotify_name = spotify_data.name
+    artist_name == spotify_name
   end
 end

--- a/config/initializers/spotify.rb
+++ b/config/initializers/spotify.rb
@@ -1,0 +1,3 @@
+RSpotify.authenticate(ENV['SPOTIFY_CLIENT_ID'], ENV['SPOTIFY_SECRET_ID'])
+
+ENV['ACCEPT_LANGUAGE'] = "ja"


### PR DESCRIPTION
投稿されたアーティスト名がSpotify API上に登録されているアーティスト名と異なる場合、データが保存されないようにしました。
これにより省略形や大文字、小文字が異なる状態でアーティスト名が登録されることを防ぎ、データの整合性を取りやすくします。
また`gem "dotenv-rails"`を導入することで環境変数を利用できるようにしました。

## 概要
### 導入したgem
- gem "rspotify"
- gem "dotenv-rails"