### PR TITLE
add: 聖地編集、詳細機能

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,12 +1,13 @@
 class SpotsController < ApplicationController
   skip_before_action :require_login, only: %i[index]
-  before_action :check_artist_name, only: %i[create]
 
   def index
     @spots = Spot.all.order(updated_at: "DESC")
   end
 
-  def show; end
+  def show
+    @spot = Spot.find(params[:id])
+  end
 
   def new
     @spot = ArtistSpot.new

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -10,15 +10,15 @@ class SpotsController < ApplicationController
   end
 
   def new
-    @spot = ArtistSpot.new
+    @artist_spot = ArtistSpot.new
   end
 
   # def edit; end
 
   def create
     if check_artist_name
-      @spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
-      if @spot.save
+      @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
+      if @artist_spot.save
         redirect_to spots_path
       else
         render :new

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,23 +1,31 @@
 class SpotsController < ApplicationController
-  skip_before_action :require_login, only: %i[index]
+  skip_before_action :require_login, only: %i[index show]
+  before_action :set_spot, only: %i[show edit]
 
   def index
     @spots = Spot.all.order(updated_at: "DESC")
   end
 
-  def show
-    @spot = Spot.find(params[:id])
-  end
+  def show; end
 
   def new
     @artist_spot = ArtistSpot.new
   end
 
-  # def edit; end
+  def edit
+    @artist_spot = ArtistSpot.new(
+      id: @spot.id,
+      tag: @spot.tag,
+      spot_name: @spot.spot_name,
+      name: @spot.artist.name,
+      detail: @spot.detail,
+      user_id: @spot.user_id
+    )
+  end
 
   def create
+    @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
     if check_artist_name
-      @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
       if @artist_spot.save
         redirect_to spots_path
       else
@@ -28,13 +36,18 @@ class SpotsController < ApplicationController
     end
   end
 
-  # def update
-  #   if @spot.update(spot_params)
-  #     redirect_to @spot
-  #   else
-  #     render :edit
-  #   end
-  # end
+  def update
+    @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id, id: params[:id]))
+    if check_artist_name
+      if @artist_spot.save
+        redirect_to spot_path(@artist_spot.id)
+      else
+        render :edit
+      end
+    else
+      render :edit
+    end
+  end
 
   private
 
@@ -42,11 +55,15 @@ class SpotsController < ApplicationController
     params.require(:artist_spot).permit(:tag, :spot_name, :name, :detail)
   end
 
+  def set_spot
+    @spot = Spot.find(params[:id])
+  end
+
   # Spotify API上のデータと比較することで正確なアーティスト名が入力されているかチェックするメソッド
   def check_artist_name
     artist_name = params["artist_spot"]["name"]
-    spotify_data = RSpotify::Artist.search(artist_name).first
-    spotify_name = spotify_data.name
+    spotify_name = RSpotify::Artist.search(artist_name).first.name
+    return false unless spotify_name
     artist_name == spotify_name
   end
 end

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -1,7 +1,7 @@
 class ArtistSpot
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
-  attr_accessor :tag, :spot_name, :name, :detail, :user_id
+  attr_accessor :id, :tag, :spot_name, :name, :detail, :user_id
 
   with_options presence: true do
     validates :tag
@@ -11,9 +11,16 @@ class ArtistSpot
   end
 
   def save
+    return if invalid?
+
     ActiveRecord::Base.transaction do
-      artist = Artist.find_or_create_by(name:)
-      Spot.create(tag:, spot_name:, detail:, user_id:, artist_id: artist.id)
+      artist = Artist.find_or_create_by(name: name)
+      if id.present?
+        spot = Spot.find(id)
+        spot.update(tag: tag, spot_name: spot_name, detail: detail, artist_id: artist.id)
+      else
+        Spot.create(tag: tag, spot_name: spot_name, detail: detail, user_id: user_id, artist_id: artist.id)
+      end
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-      <main class="container mx-auto mt-24 px-5 flex-auto text-gray-700">
+      <main class="container mx-auto mt-20 px-5 flex-auto text-gray-700">
           <%= yield %>
       </main>
   </body>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,29 +1,31 @@
 <div class="container mx-auto px-36">
   <div class="mb-10">
-    <h1 class="text-xl font-bold">プロフィール</h1>
+    <h1 class="text-xl font-bold mb-2">プロフィール</h1>
     <hr>
   </div>
 
-  <table class="table-auto w-full mx-32 mb-20">
-    <tr class="items-center h-20">
-      <td class="text-base font-bold">ニックネーム</td>
-      <td><%= current_user.name %></td>
-    </tr>
-    <tr class="items-center h-20">
-      <td class="text-base font-bold">メールアドレス</td>
-      <td><%= current_user.email %></td>
-    </tr>
-    <tr class="items-center h-20">
-      <td class="text-base font-bold">プロフィール画像</td>
-      <td>
-        <div class="avatar">
-          <div class="w-24 rounded-xl">
-            <%= image_tag current_user.avatar_url %>
+  <div class="flex justify-center">
+    <table class="table-fixed w-10/12 mb-20 text-center">
+      <tr class="items-center h-20">
+        <td class="text-base font-bold">ニックネーム</td>
+        <td><%= current_user.name %></td>
+      </tr>
+      <tr class="items-center h-20">
+        <td class="text-base font-bold">メールアドレス</td>
+        <td><%= current_user.email %></td>
+      </tr>
+      <tr class="items-center h-20">
+        <td class="text-base font-bold">プロフィール画像</td>
+        <td>
+          <div class="avatar">
+            <div class="w-24 rounded-xl">
+              <%= image_tag current_user.avatar_url %>
+            </div>
           </div>
-        </div>
-      </td>
-    </tr>
-  </table>
+        </td>
+      </tr>
+    </table>
+  </div>
 
   <div class="flex items-center justify-between">
     <%= link_to "メールアドレスの変更", "#", class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -3,7 +3,7 @@
     <%= link_to "Music Map", root_path, class: "flex items-center text-3xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
       <%= link_to "聖地一覧", spots_path, class: "mr-5 hover:underline" %>
-      <%= link_to "マップ投稿検索", "#", class: "mr-5 hover:underline" %>
+      <%= link_to "投稿一覧", "#", class: "mr-5 hover:underline" %>
       <%= link_to "ログイン", login_path, class: "hover:underline" %>
     </nav>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <%= link_to "Music Map", root_path, class: "flex items-center text-3xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
       <%= link_to "聖地一覧", spots_path, class: "mr-5 hover:underline" %>
-      <%= link_to "マップ投稿検索", "#", class: "mr-5 hover:underline" %>
+      <%= link_to "投稿一覧", "#", class: "mr-5 hover:underline" %>
       <%= link_to "#", class: "pr-3" do %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
           <path fill-rule="evenodd" d="M6.32 2.577a49.255 49.255 0 0 1 11.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 0 1-1.085.67L12 18.089l-7.165 3.583A.75.75 0 0 1 3.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93Z" clip-rule="evenodd" />

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @artist_spot, url: spots_path, local: true do |form| %>
+<%= form_with model: @artist_spot, url: @artist_spot.id ? spot_path(@artist_spot.id) : spots_path, method: (@artist_spot.id ? :patch : :post), local: true do |form| %>
   <div class="mb-6">
     <%= form.label :tag, "聖地分類", class: "text-base font-bold mb-2" %>
 

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @spot, url: spots_path, local: true do |form| %>
+<%= form_with model: @artist_spot, url: spots_path, local: true do |form| %>
   <div class="mb-6">
     <%= form.label :tag, "聖地分類", class: "text-base font-bold mb-2" %>
 

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -9,7 +9,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
         </svg>
       <% end %>
-      <%= link_to "#" do %>
+      <%= link_to edit_spot_path(spot) do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
         </svg>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,6 +1,6 @@
 <div class="p-2 w-full">
   <div class="bg-gray-100 rounded flex justify-between p-4 h-full items-center">
-    <%= link_to "#" do %>
+    <%= link_to spot_path(spot) do %>
       <div><%= spot.spot_name %> / <%= spot.artist.name %></div>
     <% end %>
     <div class="flex">

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="container mx-auto px-36">
+  <div class="mb-8">
+    <h1 class="text-xl font-bold mb-2">聖地編集</h1>
+    <hr>
+  </div>
+
+  <%= render 'form', spot: @spot %>
+
+</div>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -4,6 +4,6 @@
     <hr>
   </div>
 
-  <%= render 'form', spot: @spot %>
+  <%= render 'form', spot: @artist_spot %>
 
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,0 +1,36 @@
+<div class="container mx-auto px-36">
+  <div class="mb-8">
+    <h1 class="text-xl font-bold mb-2">聖地詳細</h1>
+    <hr>
+  </div>
+
+  <div class="flex justify-center">
+    <table class="table-fixed w-10/12 mb-20">
+      <tr class=" h-10">
+        <td class="text-base font-bold">聖地名</td>
+        <td><%= @spot.spot_name %></td>
+      </tr>
+      <tr class=" h-10">
+        <td class="text-base font-bold">聖地分類</td>
+        <td><%= @spot.tag %></td>
+      </tr>
+      <tr class=" h-10">
+        <td class="text-base font-bold">アーティスト名</td>
+        <td><%= @spot.artist.name %></td>
+      </tr>
+      <tr class=" h-10">
+        <td class="text-base font-bold">詳細</td>
+        <td><%= @spot.detail %></td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="mb-8">
+    <h1 class="text-xl font-bold mb-2">投稿一覧</h1>
+    <hr>
+  </div>
+
+  <div class="flex items-center justify-end my-4">
+    <%= link_to "新規投稿", "#", class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+  </div>
+</div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -4,6 +4,10 @@
     <hr>
   </div>
 
+  <div class="flex items-center justify-end my-4">
+    <%= link_to "聖地編集", edit_spot_path(@spot), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+  </div>
+
   <div class="flex justify-center">
     <table class="table-fixed w-10/12 mb-20">
       <tr class=" h-10">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -26,7 +26,7 @@
   </div>
 
   <div class="mb-8">
-    <h1 class="text-xl font-bold mb-2">投稿一覧</h1>
+    <h1 class="text-xl font-bold mb-2">関連投稿一覧</h1>
     <hr>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "static_pages#top"
   resources :users, only: %i[new create]
-  resources :spots, expect: %i[destroy]
+  resources :spots, except: %i[destroy]
 
   resource :profile, only: %i[show edit update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root "static_pages#top"
   resources :users, only: %i[new create]
-  resources :spots, only: %i[new create index]
+  resources :spots, expect: %i[destroy]
 
   resource :profile, only: %i[show edit update]
 


### PR DESCRIPTION
聖地編集、詳細機能を実装しました

## 概要
### 聖地詳細機能
以下の項目を表示しました。
- 聖地名
- 聖地分類
- アーティスト名
- 詳細

### 聖地編集機能
詳細画面で表示される項目を編集できるようにしました。
フォームオブジェクトを使用することで`form_with`でURLとHTTPメソッドが正しく認識されなかったため、idの有無から新規データか既存のデータかを判別し、三項演算子でURL、HTTPメソッドを割り振りました。