### PR TITLE
add: Googleマップ機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,9 @@ gem "rspotify"
 # 国際化
 gem "rails-i18n"
 gem "enum_help"
+
+# Google map
+gem "geocoder"
+
+# JavaScript変数
+gem "gon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,8 +127,14 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     hashie (5.0.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -169,6 +175,7 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.8)
@@ -277,6 +284,8 @@ GEM
     regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -375,6 +384,8 @@ DEPENDENCIES
   debug
   dotenv-rails
   enum_help
+  geocoder
+  gon
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ https://www.figma.com/file/6inHsr10Oe0pJ7KbgZn5Zs/music_map?type=design&node-id=
 
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/7f62d5570889092c6f1833eb94ab2414.png)](https://gyazo.com/7f62d5570889092c6f1833eb94ab2414)
+[![Image from Gyazo](https://i.gyazo.com/8a59ad3b2297c0a07bce06afa81ad688.png)](https://gyazo.com/8a59ad3b2297c0a07bce06afa81ad688)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,7 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params.merge(spot_id: params[:spot_id]))
     if @post.save
-      redirect_to spot_path(@post.spot_id), notice: "投稿を作成しました"
+      redirect_to spot_path(@post.spot_id), data: { turbo: false }, notice: "投稿を作成しました"
     else
       flash.now[:alert] = "投稿の作成に失敗しました"
       render :new, status: :unprocessable_entity
@@ -40,7 +40,7 @@ class PostsController < ApplicationController
     post = current_user.posts.find(params[:id])
     spot_id = post.spot.id
     post.destroy!
-    redirect_to spot_path(spot_id), notice: "投稿を削除しました"
+    redirect_to spot_path(spot_id), data: { turbo: false }, notice: "投稿を削除しました"
   end
 
   private

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -8,6 +8,7 @@ class SpotsController < ApplicationController
 
   def show
     @posts = @spot.posts.includes(:user).order(updated_at: "DESC")
+    gon.spot = @spot
   end
 
   def new
@@ -29,7 +30,7 @@ class SpotsController < ApplicationController
     @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
     if check_artist_name
       if @artist_spot.save
-        redirect_to spots_path, notice: "聖地を登録しました"
+        redirect_to spots_path, data: { turbo: false }, notice: "聖地を登録しました"
       else
         flash.now[:alert] = "聖地の登録に失敗しました"
         render :new, status: :unprocessable_entity
@@ -44,7 +45,7 @@ class SpotsController < ApplicationController
     @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id, id: params[:id]))
     if check_artist_name
       if @artist_spot.save
-        redirect_to spot_path(@artist_spot.id), notice: "聖地を更新しました"
+        redirect_to spot_path(@artist_spot.id), data: { turbo: false }, notice: "聖地を更新しました"
       else
         flash.now[:alert] = "聖地の更新に失敗しました"
         render :edit, status: :unprocessable_entity
@@ -62,7 +63,7 @@ class SpotsController < ApplicationController
   private
 
   def spot_params
-    params.require(:artist_spot).permit(:tag, :spot_name, :name, :detail)
+    params.require(:artist_spot).permit(:tag, :spot_name, :name, :detail, :address, :latitude, :longitude)
   end
 
   def set_spot

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,6 +4,8 @@ class SpotsController < ApplicationController
 
   def index
     @spots = Spot.includes(:artist).order(updated_at: "DESC")
+    gon.spots = @spots
+    gon.artists = Artist.all
   end
 
   def show

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -72,11 +72,11 @@ class SpotsController < ApplicationController
     @spot = Spot.find(params[:id])
   end
 
-  #「Spotify API上のデータと比較することで正確なアーティスト名が入力されているかチェックするメソッド
+  # 「Spotify API上のデータと比較することで正確なアーティスト名が入力されているかチェックするメソッド
   def check_artist_name
     artist_name = params["artist_spot"]["name"]
 
-    return false unless artist_name.present?
+    return false if artist_name.blank?
 
     spotify_data = RSpotify::Artist.search(artist_name).first
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -56,7 +56,7 @@ class SpotsController < ApplicationController
   end
 
   def bookmarks
-    @bookmark_spots = current_user.bookmark_spots.order(created_at: :desc)
+    @bookmark_spots = current_user.bookmark_spots.includes(:artist).order(created_at: :desc)
   end
 
   private

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_to root_path, notice: "ログインしました"
+      redirect_to spots_path, notice: "ログインしました"
     else
       flash.now[:alert] = "ログインに失敗しました"
       render :new, status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, notice: "会員登録が成功しました"
+      auto_login(@user)
+      redirect_to spots_path, notice: "会員登録が成功しました"
     else
       flash.now[:alert] = "会員登録に失敗しました"
       render :new, status: :unprocessable_entity

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -1,12 +1,13 @@
 class ArtistSpot
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
-  attr_accessor :id, :tag, :spot_name, :name, :detail, :user_id
+  attr_accessor :id, :tag, :spot_name, :name, :detail, :address, :latitude, :longitude, :user_id
 
   with_options presence: true do
     validates :tag
     validates :spot_name
     validates :name
+    validates :address
     validates :user_id
   end
 
@@ -17,9 +18,9 @@ class ArtistSpot
       artist = Artist.find_or_create_by(name:)
       if id.present?
         spot = Spot.find(id)
-        spot.update(tag:, spot_name:, detail:, artist_id: artist.id)
+        spot.update(tag:, spot_name:, detail:, address:, latitude:, longitude:, artist_id: artist.id)
       else
-        Spot.create(tag:, spot_name:, detail:, user_id:, artist_id: artist.id)
+        Spot.create(tag:, spot_name:, detail:, address:, latitude:, longitude:, user_id:, artist_id: artist.id)
       end
     end
   end

--- a/app/javascript/_form.js
+++ b/app/javascript/_form.js
@@ -89,7 +89,7 @@ function extractAddress(address) {
 }
 
 
-
+// 関数をグローバルにするための記述
 window.initMap = initMap;
 window.createMarker = createMarker;
 window.deleteMaker = deleteMaker;

--- a/app/javascript/_form.js
+++ b/app/javascript/_form.js
@@ -1,0 +1,95 @@
+let map;
+let marker;
+let geocoder;
+
+
+// マップの初期化関数
+function initMap(){
+  geocoder = new google.maps.Geocoder();
+
+  map = new google.maps.Map(document.getElementById('map'), {
+    center: {lat: 35.7100, lng:139.8107},
+    zoom: 15,
+  });
+}
+
+
+// 「マーカー作成」ボタンクリック時に実行される関数
+function createMarker(){
+  let inputAddress = document.getElementById('spot').value;
+
+  geocoder.geocode( { 'address': inputAddress}, function(results, status) {
+    if (status == 'OK') {
+      if (marker) {
+        marker.setMap(null);
+      }
+
+      let newLocation = results[0].geometry.location;
+      map.setCenter(newLocation);
+      marker = new google.maps.Marker({
+        position:  newLocation,
+        map: map,
+        draggable: true,
+      });
+
+      getAddress(newLocation);
+
+      google.maps.event.addListener(marker, 'dragend', function() {
+        getAddress(marker.getPosition());
+      });
+    } else {
+      alert('地名/施設名フォームに地名や施設名を入力してください');
+    }
+  });
+}
+
+
+// 「マーカー削除」ボタンをクリックした際に実行される関数
+function deleteMaker(){
+  if (marker) {
+    marker.setMap(null);
+    document.getElementById('latitude').value = "";
+    document.getElementById('longitude').value = "";
+    document.getElementById('address').value = "";
+  } else {
+    alert('マーカーが作成されていません');
+  }
+}
+
+
+
+// 座標から住所を取得し住所フォームに入力する関数
+function getAddress(location) {
+  document.getElementById('latitude').value = location.lat();
+  document.getElementById('longitude').value = location.lng();
+
+  geocoder.geocode({ 'location': location }, function(results, status) {
+    if (status === 'OK') {
+      let formattedAddress = results[0].formatted_address;
+      let cleanedAddress = extractAddress(formattedAddress);
+      document.getElementById('address').value = cleanedAddress;
+    } else {
+      alert('逆ジオコーディングに失敗しました');
+    }
+  });
+}
+
+
+
+// 座標から取得した住所から郵便番号や国名を取り除き都道府県より後ろだけを抽出する関数
+function extractAddress(address) {
+  const addressWithoutPostalCode = address.replace(/〒\s*\d{3}-?\d{4}\s*/, '').trim();
+  const matchResult = addressWithoutPostalCode.match(/[^、]+、(.*)/);
+
+  if (matchResult) {
+    return matchResult[1].trim();
+  } else {
+    return address;
+  }
+}
+
+
+
+window.initMap = initMap;
+window.createMarker = createMarker;
+window.deleteMaker = deleteMaker;

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -1,0 +1,53 @@
+let marker = [];
+let infoWindow = [];
+let currentOpenWindow = null;
+const spots = gon.spots;
+const artists = gon.artists;
+
+
+// マップの初期化関数
+function initMap(){
+  let map = new google.maps.Map(document.getElementById('map'), {
+    center: { lat: 35.7100, lng: 139.8107 },
+    zoom: 10
+  });
+
+  for (let i = 0; i < spots.length; i++) {
+    let spot = spots[i]
+    let id = spot['id']
+    let artist_id = spot['artist_id']
+    let artist = artists.find(item => item.id === artist_id)
+
+    let markerLatLng = new google.maps.LatLng({
+      lat: parseFloat(spot['latitude']),
+      lng: parseFloat(spot['longitude'])
+    });
+
+    marker[i] = new google.maps.Marker({
+      position: markerLatLng,
+      map: map
+    });
+
+    infoWindow[i] = new google.maps.InfoWindow({
+      content: `<a href='/spots/${id}' class='hover:underline' data-turbo='false'>${spot['spot_name']} / ${artist['name']}</a>`
+    });
+
+    markerEvent(i);
+  }
+}
+
+
+// ウィンドウを開くための関数
+function markerEvent(i) {
+  marker[i].addListener('click', function () {
+    if (currentOpenWindow) {
+      currentOpenWindow.close();
+    }
+    infoWindow[i].open(map, marker[i]);
+    currentOpenWindow = infoWindow[i];
+  });
+}
+
+
+// initMap関数をグローバルにするための記述
+window.initMap = initMap;

--- a/app/javascript/show.js
+++ b/app/javascript/show.js
@@ -16,5 +16,5 @@ function initMap(){
   });
 }
 
-// initMap関数をグローバルに配置するための記述
+// initMap関数をグローバルにするための記述
 window.initMap = initMap;

--- a/app/javascript/show.js
+++ b/app/javascript/show.js
@@ -1,0 +1,20 @@
+// コントローラで作成した変数をJavaScriptに渡すための記法
+const spot = gon.spot;
+
+// マップの初期化関数
+function initMap(){
+  let mapPosition = {lat: spot.latitude, lng: spot.longitude };
+
+  let map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 17,
+    center: mapPosition
+  });
+
+  let marker = new google.maps.Marker({
+    position: mapPosition,
+    map: map
+  });
+}
+
+// initMap関数をグローバルに配置するための記述
+window.initMap = initMap;

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -9,4 +9,7 @@ class Spot < ApplicationRecord
   validates :tag, presence: true
 
   enum tag: { video_location: 0, sign: 1, others: 2 }
+
+  geocoded_by :address
+  after_validation :geocode
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= include_gon %>
   </head>
 
   <body>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,7 @@
           <h2 class="text-xl font-bold"><%= @post.title %></h2>
         </div>
         <div class="h-10">
-          <%= link_to spot_path(@post.spot) do %>
+          <%= link_to spot_path(@post.spot), data: { turbo: false } do %>
             <h2 class="text-xl font-bold"><%= @post.spot.spot_name %> / <%= @post.spot.artist.name %></h2>
           <% end %>
         </div>
@@ -27,7 +27,7 @@
   </div>
 
   <div class="flex items-center justify-around">
-    <%= link_to "聖地詳細へ戻る", spot_path(@post.spot), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+    <%= link_to "聖地詳細へ戻る", spot_path(@post.spot), data: { turbo: false }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
     <% if logged_in? && current_user.own?(@post) %>
       <div>
         <%= link_to "編集", edit_post_path(@post), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,7 +2,7 @@
   <div class="flex flex-wrap p-6 flex-col md:flex-row items-center">
     <%= link_to "Music Map", root_path, class: "flex items-center text-4xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
-      <%= link_to "聖地一覧", spots_path, class: "mr-5 hover:underline" %>
+      <%= link_to "聖地一覧", spots_path, data: { turbo: false }, class: "mr-5 hover:underline" %>
       <%= link_to "投稿一覧", posts_path, class: "mr-5 hover:underline" %>
       <%= link_to "ログイン", login_path, class: "hover:underline" %>
     </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="flex flex-wrap p-5 flex-col md:flex-row items-center">
     <%= link_to "Music Map", root_path, class: "flex items-center text-4xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
-      <%= link_to "聖地一覧", spots_path, class: "mr-5 hover:underline" %>
+      <%= link_to "聖地一覧", spots_path, data: { turbo: false }, class: "mr-5 hover:underline" %>
       <%= link_to "投稿一覧", posts_path, class: "mr-5 hover:underline" %>
       <details class="dropdown dropdown-end">
         <summary class="btn border-0 text-yellow-400 hover:bg-yellow-500 hover:text-neutral-50">

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -24,20 +24,42 @@
 
   <div class="mb-6">
     <%= form.label :spot_name, class: "text-base font-bold mb-2" %>
-    <%= form.text_field :spot_name, class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
+    <%= form.text_field :spot_name, placeholder: "こちらを入力した状態で「マーカー作成」ボタンをクリックすると自動で住所が入力されます", id: "spot", class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
   </div>
 
   <div class="mb-6">
     <%= form.label :name, class: "text-base font-bold mb-2" %>
-    <%= form.text_field :name, class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
+    <%= form.text_field :name, placeholder: "正確なアーティスト名を入力してください", class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
   </div>
 
-  <div class="mb-10">
+  <div class="mb-6">
     <%= form.label :detail, class: "text-base font-bold mb-2" %>
     <%= form.text_field :detail, class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
+  </div>
+
+  <div class="flex flex-wrap justify-between items-end mb-2 w-full">
+    <div class="flex flex-col flex-grow">
+      <%= form.label :address, class: "text-base font-bold mb-2" %>
+      <%= form.text_field :address, placeholder: "マーカーを作成、ドラッグすると自動で更新されます", id: "address", class: "shadow appearance-none border rounded py-2 px-3 mr-2 leading-tight" %>
+    </div>
+    <div class="flex flex-nowrap">
+      <input type="button" value="マーカー作成" onclick="createMarker()" class="rounded-lg py-2 px-5 mr-2 bg-gray-100 inline-block font-medium hover:bg-gray-200">
+      <input type="button" value="マーカー削除" onclick="deleteMaker()" class="rounded-lg py-2 px-5 bg-gray-100 inline-block font-medium hover:bg-gray-200">
+    </div>
+  </div>
+
+  <%= form.hidden_field :latitude, id: "latitude" %>
+  <%= form.hidden_field :longitude, id: "longitude" %>
+
+  <div class="mb-10">
+    <div id="map" class="h-96 rounded-md"></div>
   </div>
 
   <div class="flex items-center justify-center mb-24">
     <%= form.submit "登録", class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
   </div>
 <% end %>
+
+<%= javascript_import_module_tag "_form" %>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" defer></script>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -24,7 +24,7 @@
 
   <div class="mb-6">
     <%= form.label :spot_name, class: "text-base font-bold mb-2" %>
-    <%= form.text_field :spot_name, placeholder: "こちらを入力した状態で「マーカー作成」ボタンをクリックすると自動で住所が入力されます", id: "spot", class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
+    <%= form.text_field :spot_name, placeholder: "こちらに入力した状態で「マーカー作成」ボタンをクリックすると自動で住所が入力されます", id: "spot", class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
   </div>
 
   <div class="mb-6">

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,6 +1,6 @@
 <div class="p-2 w-full">
   <div class="bg-gray-100 rounded flex justify-between p-4 h-full items-center">
-    <%= link_to spot_path(spot) do %>
+    <%= link_to spot_path(spot), data: { turbo: false } do %>
       <div><%= spot.spot_name %> / <%= spot.artist.name %></div>
     <% end %>
     <div class="flex">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -5,7 +5,12 @@
   </div>
 
   <div class="flex items-center justify-end my-4">
-    <%= link_to "聖地登録", new_spot_path, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+    <%= link_to "聖地登録", new_spot_path, data: { turbo: false }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+  </div>
+
+  <div class="mb-20 mx-16">
+    <h2 class="text-base font-bold mb-2">マップ</h2>
+    <div id="map" class="h-96 rounded-md"></div>
   </div>
 
   <div class="flex flex-col mb-20">
@@ -16,3 +21,7 @@
     <% end %>
   </div>
 </div>
+
+<%= javascript_import_module_tag "index" %>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" defer></script>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -6,33 +6,38 @@
 
   <div class="flex items-center justify-end my-4">
     <% if logged_in? && current_user.own?(@spot) %>
-      <%= link_to "聖地編集", edit_spot_path(@spot), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+      <%= link_to "聖地編集", edit_spot_path(@spot), data: { turbo: false }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
     <% end %>
   </div>
 
-  <div class="flex justify-center">
-    <table class="table-fixed w-10/12 mb-20">
-      <tr class=" h-10">
+  <div class="flex justify-center mb-10">
+    <table class="table-fixed w-10/12">
+      <tr class="h-10">
         <td class="text-base font-bold">地名 / 施設名</td>
         <td><%= @spot.spot_name %></td>
       </tr>
-      <tr class=" h-10">
+      <tr class="h-10">
         <td class="text-base font-bold">聖地分類</td>
         <td><%= @spot.tag_i18n %></td>
       </tr>
-      <tr class=" h-10">
+      <tr class="h-10">
         <td class="text-base font-bold">アーティスト名</td>
         <td><%= @spot.artist.name %></td>
       </tr>
-      <tr class=" h-10">
+      <tr class="h-10">
         <td class="text-base font-bold">詳細</td>
         <td><%= @spot.detail %></td>
       </tr>
-      <tr class=" h-10">
+      <tr class="h-10">
         <td class="text-base font-bold">作成者</td>
         <td><%= @spot.user.name %></td>
       </tr>
     </table>
+  </div>
+
+  <div class="mb-20 mx-20">
+    <h2 class="text-base font-bold mb-2">住所</h2>
+    <div id="map" class="h-96 rounded-md"></div>
   </div>
 
   <div class="mb-8">
@@ -52,3 +57,7 @@
     <% end %>
   </div>
 </div>
+
+<%= javascript_import_module_tag "show" %>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" defer></script>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "show", to: "show.js"
+pin "_form", to: "_form.js"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "show", to: "show.js"
 pin "_form", to: "_form.js"
+pin "index", to: "index.js"

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,13 +1,13 @@
 Geocoder.configure(
   # Geocoding options
   # timeout: 3,                 # geocoding service timeout (secs)
-  lookup: :google,         # name of geocoding service (symbol)
+  lookup: :google, # name of geocoding service (symbol)
   # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code
-  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  use_https: true, # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  api_key: ENV['GOOGLE_MAP_API_KEY'],                # API key for geocoding service
+  api_key: ENV.fetch('GOOGLE_MAP_API_KEY', nil) # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
 
   # Exceptions that should not be rescued by default

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAP_API_KEY'],                # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,6 +20,9 @@ ja:
         spot_name: "地名 / 施設名"
         detail: "詳細"
         tag: "聖地分類"
+        address: "住所"
+        latitude: "緯度"
+        longitude: "経度"
       post:
         title: "タイトル"
         body: "投稿内容"
@@ -32,6 +35,7 @@ ja:
         spot_name: "地名 / 施設名"
         tag: "聖地分類"
         detail: "詳細"
+        address: "住所"
   enums:
     spot:
       tag:

--- a/db/migrate/20240108084449_add_address_info_to_spots.rb
+++ b/db/migrate/20240108084449_add_address_info_to_spots.rb
@@ -1,0 +1,7 @@
+class AddAddressInfoToSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :spots, :address, :string
+    add_column :spots, :latitude, :float
+    add_column :spots, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_06_143909) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_08_084449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_06_143909) do
     t.bigint "artist_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["artist_id"], name: "index_spots_on_artist_id"
     t.index ["user_id"], name: "index_spots_on_user_id"
   end


### PR DESCRIPTION
聖地一覧、聖地詳細、聖地作成、聖地編集画面にマップ機能を実装しました。

# 概要
## マップ機能
それぞれのマップを次のように実装しました。
### 一覧
- 投稿されている全ての聖地の位置情報をマーカーで表示
- クリックすると「地名/施設名」、「アーティスト名」を表示し対応する聖地の詳細ページへのリンクを表示

### 詳細
その投稿の位置情報をマーカーで表示

### 作成、編集
- マーカー作成ボタンをクリックすることで「地名/施設名」の内容に対応した住所を自動で入力
- マーカーをドラッグ可能にして詳細な位置情報を取得
- ドラッグした場合、ドラッグした場所の住所を取得
- マーカー削除ボタンをクリックした場合、取得した住所とマーカーを削除


## その他
- ユーザビリティを考慮し、位置情報をpostsテーブルからspotsテーブルに移行しました。それに伴いER図を修正しました。
- 一覧画面のマップ表示は一覧表示とマップ表示を切り替え可能に変更予定([こちらを参照](https://qiita.com/nakachan1994/items/566cfcb60376feb3fe8c))
