### PR TITLE
fix: spotsテーブルのaddressカラムにnull制約を追加

### DIFF
--- a/app/javascript/_form.js
+++ b/app/javascript/_form.js
@@ -38,7 +38,7 @@ function createMarker(){
         getAddress(marker.getPosition());
       });
     } else {
-      alert('地名/施設名フォームに地名や施設名を入力してください');
+      alert('住所を取得できませんでした。');
     }
   });
 }

--- a/db/migrate/20240110134640_add_not_null_to_spots_address.rb
+++ b/db/migrate/20240110134640_add_not_null_to_spots_address.rb
@@ -1,0 +1,5 @@
+class AddNotNullToSpotsAddress < ActiveRecord::Migration[7.1]
+  def change
+    change_column :spots, :address, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_08_084449) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_10_134640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_084449) do
     t.bigint "artist_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "address"
+    t.string "address", null: false
     t.float "latitude"
     t.float "longitude"
     t.index ["artist_id"], name: "index_spots_on_artist_id"


### PR DESCRIPTION
## 概要
既存のデータが存在するテーブルにnull制約があるカラムを追加できなかったため、次の流れでnull制約を追加しました。
1. null制約を付けずにaddressカラムを追加
2. 既存のデータにaddressデータを入力
3. spotsテーブルのaddressカラムにnull制約を追加

## その他
住所取得失敗時のメッセージを修正しました。