### PR TITLE
add: ページネーション機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,6 @@ gem "geocoder"
 
 # JavaScript変数
 gem "gon"
+
+# ページネーション
+gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,18 @@ GEM
       activesupport (>= 5.0.0)
     json (2.7.1)
     jwt (2.7.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -388,6 +400,7 @@ DEPENDENCIES
   gon
   importmap-rails
   jbuilder
+  kaminari
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update]
 
   def index
-    @posts = Post.includes(:user).order(updated_at: "DESC")
+    @posts = Post.includes(:user).order(updated_at: "DESC").page(params[:page])
   end
 
   def show

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -3,7 +3,7 @@ class SpotsController < ApplicationController
   before_action :set_spot, only: %i[show edit]
 
   def index
-    @spots = Spot.includes(:artist).order(updated_at: "DESC")
+    @spots = Spot.includes(:artist).order(updated_at: "DESC").page(params[:page])
     gon.spots = @spots
     gon.artists = Artist.all
   end
@@ -59,7 +59,7 @@ class SpotsController < ApplicationController
   end
 
   def bookmarks
-    @bookmark_spots = current_user.bookmark_spots.includes(:artist).order(created_at: :desc)
+    @bookmark_spots = current_user.bookmark_spots.includes(:artist).order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "join-item btn" %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe, class: "join-item btn" %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "join-item btn" %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "join-item btn" %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current btn-active join-item btn' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "join-item btn"} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination join" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "join-item btn" %>
+</span>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="p-2 w-full">
   <div class="bg-gray-100 rounded flex justify-between p-4 h-full items-center">
-    <%= link_to post_path(post) do %>
+    <%= link_to post_path(post), data: { turbo_frame: "_top" } do %>
       <div><%= post.title %> / <%= post.user.name %></div>
     <% end %>
     <% if logged_in? && current_user.own?(post) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,11 +4,17 @@
     <hr>
   </div>
 
-  <div class="flex flex-col">
-    <% if @posts.present? %>
-      <%= render @posts %>
-    <% else %>
-      <div class="mb-3"><%= t(".none_post") %></div>
-    <% end %>
-  </div>
+  <%= turbo_frame_tag "posts-list" do %>
+    <div class="flex flex-col">
+      <% if @posts.present? %>
+        <%= render @posts %>
+      <% else %>
+        <div class="mb-3"><%= t(".none_post") %></div>
+      <% end %>
+    </div>
+
+    <div class="flex justify-center my-4">
+      <%= paginate @posts %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -13,13 +13,19 @@
     <div id="map" class="h-96 rounded-md"></div>
   </div>
 
-  <div class="flex flex-col mb-20">
-    <% if @spots.present? %>
-      <%= render @spots %>
-    <% else %>
-      <div class="mb-3"><%= t(".none_spot") %></div>
-    <% end %>
-  </div>
+  <%= turbo_frame_tag "spots-list" do %>
+    <div class="flex flex-col">
+      <% if @spots.present? %>
+        <%= render @spots %>
+      <% else %>
+        <div class="mb-3"><%= t(".none_spot") %></div>
+      <% end %>
+    </div>
+
+    <div class="flex justify-center my-4">
+      <%= paginate @spots %>
+    </div>
+  <% end %>
 </div>
 
 <%= javascript_import_module_tag "index" %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -71,3 +71,10 @@ ja:
     formats:
       default: "%Y/%m/%d %H:%M:%S"
       short: "%Y/%m/%d"
+  views:
+    pagination:
+      first: "最初"
+      last: "最後"
+      previous: "«"
+      next: "»"
+      truncate: "..."


### PR DESCRIPTION
kaminariを導入してページネーション機能を実装しました。
画面遷移を高速化するためturbo-frameを利用してリストのみを更新するよう実装しております。

## 概要
gem "kaminari"を導入して以下のページにページネーションを実装しました。
- 聖地一覧
- 投稿一覧
- ブックマーク一覧

## content missingエラーについて
投稿一覧機能に対してturbo-frameを使用してページネーションを実装したところ上記のエラーが発生しました。これはturbo-frame内のリンクに対して同じidのレスポンスが見つからない場合に起こるエラーのようです。
整地一覧機能でも同じような実装を行なっておりますが、こちらはJavaScriptファイルの読み込みエラー対策として`data: { turbo: false }`をつけていたためこのエラーは発生しませんでした。そのため今回、投稿一覧へのリンクに`data: { turbo_frame: "_top" }`オプションを付けることでこのエラーを解消しております。[参考](https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-frames)

## その他
Tailwind CSSを導入していることによりkaminariのテンプレートが生成されない問題は[こちら](https://qiita.com/todochuramasa/items/4c6c8ac7e1b21ef38e89)の方法で解決しました。

