### PR TITLE
add: 整地一覧画面のマップ表示、リスト表示の切り替え

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
 @layer components {
   .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+    @apply flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 hover:shadow-md transition duration-300 rounded-full text-lg mt-10 sm:mt-0;
+  }
+  .link-primary {
+    @apply text-neutral-50 hover:text-amber-500 transition duration-300;
   }
 }
-
-*/

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -24,7 +24,10 @@ class SpotsController < ApplicationController
       spot_name: @spot.spot_name,
       name: @spot.artist.name,
       detail: @spot.detail,
-      user_id: @spot.user_id
+      user_id: @spot.user_id,
+      address: @spot.address,
+      latitude: @spot.latitude,
+      longitude: @spot.longitude
     )
   end
 

--- a/app/javascript/_form.js
+++ b/app/javascript/_form.js
@@ -89,6 +89,38 @@ function extractAddress(address) {
 }
 
 
+// 編集でフォームを使用する場合、インスタンスのデータからマーカーを作成する関数
+function initializeMarker(latitude, longitude) {
+  if (latitude && longitude) {
+    let location = new google.maps.LatLng(latitude, longitude);
+    map.setCenter(location);
+    if (marker) {
+      marker.setMap(null);
+    }
+    marker = new google.maps.Marker({
+      position: location,
+      map: map,
+      draggable: true,
+    });
+
+    google.maps.event.addListener(marker, 'dragend', function() {
+      getAddress(marker.getPosition());
+    });
+  }
+}
+
+
+// 画面ロード時に緯度、経度がフォームに入力されていた場合、initializeMarker関数を実行するための処理
+document.addEventListener('DOMContentLoaded', function() {
+  let latitude = document.getElementById('latitude').value;
+  let longitude = document.getElementById('longitude').value;
+
+  if (latitude && longitude) {
+    initializeMarker(parseFloat(latitude), parseFloat(longitude));
+  }
+});
+
+
 // 関数をグローバルにするための記述
 window.initMap = initMap;
 window.createMarker = createMarker;

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -5,6 +5,35 @@ const spots = gon.spots;
 const artists = gon.artists;
 
 
+// タブによるマップ表示、リスト表示の切り替え処理
+document.addEventListener("DOMContentLoaded", () => {
+  const listView = document.getElementById("list-view");
+  const mapView = document.getElementById("map-view");
+  const listTab = document.getElementById("list-tab");
+  const mapTab = document.getElementById("map-tab");
+
+  listTab.addEventListener("click", () => {
+    mapView.style.display = "none";
+    listView.style.display = "block";
+    listTab.classList.add("tab-active");
+    mapTab.classList.remove("tab-active");
+  });
+
+  mapTab.addEventListener("click", () => {
+    mapView.style.display = "block";
+    listView.style.display = "none";
+    mapTab.classList.add("tab-active");
+    listTab.classList.remove("tab-active");
+  });
+
+  listView.style.display = "block";
+  mapView.style.display = "none";
+  listTab.classList.add("tab-active");
+  mapTab.classList.remove("tab-active");
+});
+
+
+
 // マップの初期化関数
 function initMap(){
   let map = new google.maps.Map(document.getElementById('map'), {

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -6,7 +6,7 @@ const artists = gon.artists;
 
 
 // タブによるマップ表示、リスト表示の切り替え処理
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbo:load", () => {
   const listView = document.getElementById("list-view");
   const mapView = document.getElementById("map-view");
   const listTab = document.getElementById("list-tab");
@@ -38,7 +38,7 @@ document.addEventListener("DOMContentLoaded", () => {
 function initMap(){
   let map = new google.maps.Map(document.getElementById('map'), {
     center: { lat: 35.7100, lng: 139.8107 },
-    zoom: 10
+    zoom: 9
   });
 
   for (let i = 0; i < spots.length; i++) {

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,6 +6,8 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
+<!--
 <span class="first">
   <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "join-item btn" %>
 </span>
+-->

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,6 +6,8 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
+<!--
 <span class="last">
   <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "join-item btn" %>
 </span>
+-->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
       <%= render "shared/before_login_header" %>
     <% end %>
     <%= render "shared/flash_messages" %>
-    <main class="container mx-auto min-h-screen mt-16 px-5 flex-auto text-gray-700">
+    <main class="container mx-auto h-auto mt-16 px-5 flex-auto text-gray-700">
       <%= yield %>
     </main>
     <%= render "shared/footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
       <%= render "shared/before_login_header" %>
     <% end %>
     <%= render "shared/flash_messages" %>
-    <main class="container mx-auto min-h-screen mt-20 px-5 flex-auto text-gray-700">
+    <main class="container mx-auto min-h-screen mt-16 px-5 flex-auto text-gray-700">
       <%= yield %>
     </main>
     <%= render "shared/footer" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,6 +12,6 @@
   </div>
 
   <div class="flex items-center justify-center mb-24">
-    <%= form.submit t("defaults.create"), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+    <%= form.submit t("defaults.create"), class: "btn-primary" %>
   </div>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,12 +5,12 @@
     <% end %>
     <% if logged_in? && current_user.own?(post) %>
       <div class="flex">
-        <%= link_to edit_post_path(post), class: "pr-2" do %>
+        <%= link_to edit_post_path(post), class: "pr-2", data: { turbo_frame: "_top" } do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
           </svg>
         <% end %>
-        <%= link_to post_path(post), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") } do %>
+        <%= link_to post_path(post), data: { turbo_method: :delete, turbo_frame: "_top", turbo_confirm: t("defaults.delete_confirm") } do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -30,8 +30,8 @@
     <%= link_to t(".return_spot"), spot_path(@post.spot), data: { turbo: false }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
     <% if logged_in? && current_user.own?(@post) %>
       <div>
-        <%= link_to t("defaults.edit"), edit_post_path(@post), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
-        <%= link_to t("defaults.delete"), post_path(@post), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+        <%= link_to t("defaults.edit"), edit_post_path(@post), class: "btn-primary" %>
+        <%= link_to t("defaults.delete"), post_path(@post), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class: "btn-primary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -19,7 +19,7 @@
     </div>
 
     <div class="flex items-center justify-center">
-      <%= form.submit t("defaults.create"), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+      <%= form.submit t("defaults.create"), class: "btn-primary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,9 +2,9 @@
   <div class="flex flex-wrap p-6 flex-col md:flex-row items-center">
     <%= link_to "Music Map", root_path, class: "flex items-center text-4xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
-      <%= link_to t("defaults.spots_index"), spots_path, data: { turbo: false }, class: "mr-5 hover:underline" %>
-      <%= link_to t("defaults.posts_index"), posts_path, class: "mr-5 hover:underline" %>
-      <%= link_to t("defaults.login"), login_path, class: "hover:underline" %>
+      <%= link_to t("defaults.spots_index"), spots_path, data: { turbo: false }, class: "mr-5 link-primary" %>
+      <%= link_to t("defaults.posts_index"), posts_path, class: "mr-5 link-primary" %>
+      <%= link_to t("defaults.login"), login_path, class: "link-primary" %>
     </nav>
   </div>
 </header>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,8 +1,8 @@
 <footer class="text-neutral-50 bg-yellow-400">
   <div class="p-6 flex-col md:flex-row items-center">
     <nav class="md:ml-auto flex justify-center items-center text-lg">
-      <%= link_to t("defaults.privacy_policy"), "#", class: "mr-24 hover:underline" %>
-      <%= link_to t("defaults.terms_of_service"), "#", class: "hover:underline" %>
+      <%= link_to t("defaults.privacy_policy"), "#", class: "mr-24 link-primary" %>
+      <%= link_to t("defaults.terms_of_service"), "#", class: "link-primary" %>
     </nav>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,10 +2,10 @@
   <div class="flex flex-wrap p-5 flex-col md:flex-row items-center">
     <%= link_to "Music Map", root_path, class: "flex items-center text-4xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
-      <%= link_to t("defaults.spots_index"), spots_path, data: { turbo: false }, class: "mr-5 hover:underline" %>
-      <%= link_to t("defaults.posts_index"), posts_path, class: "mr-5 hover:underline" %>
+      <%= link_to t("defaults.spots_index"), spots_path, data: { turbo: false }, class: "mr-5 link-primary" %>
+      <%= link_to t("defaults.posts_index"), posts_path, class: "mr-5 link-primary" %>
       <details class="dropdown dropdown-end">
-        <summary class="btn border-0 text-yellow-400 hover:bg-yellow-500 hover:text-neutral-50">
+        <summary class="btn border-0 text-yellow-400 hover:bg-amber-500 hover:text-neutral-50 hover:shadow-md">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
           </svg>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -56,7 +56,7 @@
   </div>
 
   <div class="flex items-center justify-center mb-24">
-    <%= form.submit t("defaults.create"), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+    <%= form.submit t("defaults.create"), class: "btn-primary" %>
   </div>
 <% end %>
 

--- a/app/views/spots/_list.html.erb
+++ b/app/views/spots/_list.html.erb
@@ -1,0 +1,15 @@
+<div class="my-6">
+  <%= turbo_frame_tag "spots-list" do %>
+    <div class="flex flex-col">
+      <% if @spots.present? %>
+        <%= render @spots %>
+      <% else %>
+        <div class="mb-3"><%= t(".none_spot") %></div>
+      <% end %>
+    </div>
+
+    <div class="flex justify-center my-4">
+      <%= paginate @spots %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spots/_map.html.erb
+++ b/app/views/spots/_map.html.erb
@@ -1,0 +1,3 @@
+<div class="my-6">
+  <div id="map" class="h-[36rem] rounded-md"></div>
+</div>

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-36">
+<div class="container mx-auto px-36 min-h-screen">
   <div class="mb-4">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.bookmarks_index") %></h1>
     <hr>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -8,24 +8,17 @@
     <%= link_to t("defaults.spot_create"), new_spot_path, data: { turbo: false }, class: "btn-primary" %>
   </div>
 
-  <div class="mb-20 mx-16">
-    <h2 class="text-base font-bold mb-2"><%= t(".map") %></h2>
-    <div id="map" class="h-96 rounded-md"></div>
+  <div role="tablist" class="tabs tabs-bordered mb-2">
+    <a role="tab" id="list-tab" class="tab"><%= t(".display_list") %></a>
+    <a role="tab" id="map-tab" class="tab"><%= t(".display_map") %></a>
   </div>
 
-  <%= turbo_frame_tag "spots-list" do %>
-    <div class="flex flex-col">
-      <% if @spots.present? %>
-        <%= render @spots %>
-      <% else %>
-        <div class="mb-3"><%= t(".none_spot") %></div>
-      <% end %>
-    </div>
-
-    <div class="flex justify-center my-4">
-      <%= paginate @spots %>
-    </div>
-  <% end %>
+  <div id="list-view">
+    <%= render "list" %>
+  </div>
+  <div id="map-view">
+    <%= render "map" %>
+  </div>
 </div>
 
 <%= javascript_import_module_tag "index" %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -5,7 +5,7 @@
   </div>
 
   <div class="flex items-center justify-end my-4">
-    <%= link_to t("defaults.spot_create"), new_spot_path, data: { turbo: false }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+    <%= link_to t("defaults.spot_create"), new_spot_path, data: { turbo: false }, class: "btn-primary" %>
   </div>
 
   <div class="mb-20 mx-16">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -6,7 +6,7 @@
 
   <div class="flex items-center justify-end my-4">
     <% if logged_in? && current_user.own?(@spot) %>
-      <%= link_to t(".spot_edit"), edit_spot_path(@spot), data: { turbo: false }, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+      <%= link_to t(".spot_edit"), edit_spot_path(@spot), data: { turbo: false }, class: "btn-primary" %>
     <% end %>
   </div>
 
@@ -46,7 +46,7 @@
   </div>
 
   <div class="flex items-center justify-end my-4">
-    <%= link_to t(".new_post"), new_spot_post_path(@spot), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+    <%= link_to t(".new_post"), new_spot_post_path(@spot), class: "btn-primary" %>
   </div>
 
   <div class="flex flex-col mb-20">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -7,7 +7,7 @@
           <path fill-rule="evenodd" d="M19.952 1.651a.75.75 0 0 1 .298.599V16.303a3 3 0 0 1-2.176 2.884l-1.32.377a2.553 2.553 0 1 1-1.403-4.909l2.311-.66a1.5 1.5 0 0 0 1.088-1.442V6.994l-9 2.572v9.737a3 3 0 0 1-2.176 2.884l-1.32.377a2.553 2.553 0 1 1-1.402-4.909l2.31-.66a1.5 1.5 0 0 0 1.088-1.442V5.25a.75.75 0 0 1 .544-.721l10.5-3a.75.75 0 0 1 .658.122Z" clip-rule="evenodd" />
         </svg>
       <% else %>
-        <%= link_to t("defaults.signup"), new_user_path, class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+        <%= link_to t("defaults.signup"), new_user_path, class: "btn-primary" %>
       <% end %>
     </div>
   </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <div class="flex items-center justify-center mb-24">
-      <%= form.submit t("defaults.login"), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+      <%= form.submit t("defaults.login"), class: "btn-primary" %>
     </div>
   <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -28,7 +28,7 @@
     </div>
 
     <div class="flex items-center justify-center">
-      <%= form.submit t("defaults.create"), class: "flex-shrink-0 text-neutral-50 bg-amber-500 border-0 py-2 px-8 focus:outline-none hover:bg-amber-600 rounded-full text-lg mt-10 sm:mt-0" %>
+      <%= form.submit t("defaults.create"), class: "btn-primary" %>
     </div>
   <% end %>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 10
+  config.default_per_page = 8
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -36,8 +36,8 @@ ja:
       none_post: "まだ投稿がありません"
     index:
       title: "聖地一覧"
-      map: "マップ"
-      none_spot: "聖地が登録されていません"
+      display_map: "マップ表示"
+      display_list: "リスト表示"
     edit:
       title: "聖地編集"
     form:
@@ -51,6 +51,10 @@ ja:
       delete_marker: "マーカー削除"
     bookmarks:
       none_bookmark: "ブックマークがありません"
+    map:
+      map: "マップ"
+    list:
+      none_spot: "聖地が登録されていません"
   posts:
     new:
       title: "投稿作成"


### PR DESCRIPTION
整地一覧画面でマップ表示、リスト表示の切り替えを行えるようにしました。
また、整地編集機能を一部修正しました。


## 概要
### マップ、リスト切り替え
マップ表示、リスト表示タブを作成し、`display:none`、`display:block`を利用して表示の切り替えが行えるよう実装しました。


### 整地編集機能の修正
整地編集機能において編集対象のデータの住所、緯度、経度がフォームに入力済みになっているよう修正しました。


### その他
以下のデザインを変更しました。
- ページネーションの一ページあたりの表示件数
- ページネーションのボタンデザイン
- ボタン、リンクのhover時の挙動修正
- その他高さのレイアウト
