### PR TITLE
add: 外部ストレージにS3の導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,3 +101,6 @@ gem "kaminari"
 
 # 検索機能
 gem "ransack"
+
+# AWS S3
+gem "fog-aws"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,12 +121,29 @@ GEM
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
     erubi (1.12.0)
+    excon (0.109.0)
     faraday (2.8.1)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    fog-aws (3.21.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -400,6 +417,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   enum_help
+  fog-aws
   geocoder
   gon
   importmap-rails

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,8 +4,9 @@ class SpotsController < ApplicationController
 
   def index
     @q = Spot.ransack(params[:q])
-    @spots = @q.result(distinct: true).includes(:artist).order(updated_at: "DESC").page(params[:page])
-    gon.spots = @spots
+    query_result = @q.result(distinct: true).includes(:artist).order(updated_at: "DESC")
+    @spots = query_result.page(params[:page])
+    gon.spots = query_result
     gon.artists = Artist.all
   end
 
@@ -65,8 +66,9 @@ class SpotsController < ApplicationController
 
   def bookmarks
     @q = current_user.bookmark_spots.ransack(params[:q])
-    @bookmark_spots = @q.result(distinct: true).includes(:artist).order(created_at: :desc).page(params[:page])
-    gon.spots = @bookmark_spots
+    query_result = @q.result(distinct: true).includes(:artist).order(created_at: :desc)
+    @bookmark_spots = query_result.page(params[:page])
+    gon.spots = query_result
     gon.artists = Artist.all
   end
 

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,12 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require "carrierwave/storage/abstract"
+require "carrierwave/storage/file"
+require "carrierwave/storage/fog"
+
+CarrierWave.configure do |config|
+  config.storage :fog
+  config.fog_provider = "fog/aws"
+  config.fog_directory = "music-map"
+  config.fog_credentials = {
+    provider: "AWS",
+    aws_access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID", nil),
+    aws_secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY", nil),
+    region: "ap-northeast-1",
+    path_style: true
+  }
+end


### PR DESCRIPTION
本番環境のプロフィール画像の保存先をS3に変更しました。

## 概要
AWSアカウント、IAMアカウント、バケットを作成し本番環境のプロフィール画像の保存先をS3に変更しました。
以下のサイトを参考に実装しております。
- [Railsでcarrierwaveを使ってAWS S3に画像をアップロードする手順を画像付きで説明する #AWS - Qiita](https://qiita.com/junara/items/1899f23c091bcee3b058)
- [【Rails】 CarrierWaveチュートリアル | Pikawaka](https://pikawaka.com/rails/carrierwave#Carrierwave%E3%81%A7S3%E3%81%AB%E3%82%A2%E3%83%83%E3%83%97%E3%83%AD%E3%83%BC%E3%83%89%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)
- [【Rails】Carrierwaveとfog-awsを用いて、画像をAWS S3へアップロードする方法 #Ruby - Qiita](https://qiita.com/mattan5271/items/96721426cff2b1d67cdd)

## その他
聖地詳細ページ、ブックマーク一覧ページでマップにページネーションの一ページ目の聖地しか表示されないバグを修正しました。