### PR TITLE
add: 写真投稿機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,8 +77,9 @@ gem "tailwindcss-rails", "~> 2.1"
 # ログイン機能
 gem 'sorcery'
 
-# 画像アップロード
+# 画像関連
 gem "carrierwave"
+gem "mini_magick"
 
 # 環境変数
 gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,6 +423,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  mini_magick
   pg (~> 1.1)
   pry-byebug
   puma (>= 5.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,8 @@
  *= require_tree .
  *= require_self
  */
+
+.custom-carousel {
+  width: 600px;
+  height: 400px;
+}

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -4,7 +4,7 @@ class SpotsController < ApplicationController
 
   def index
     @q = Spot.ransack(params[:q])
-    query_result = @q.result(distinct: true).includes(:artist).order(updated_at: "DESC")
+    query_result = @q.result.includes(:artist).order(updated_at: "DESC")
     @spots = query_result.page(params[:page])
     gon.spots = query_result
     gon.artists = Artist.all
@@ -66,7 +66,7 @@ class SpotsController < ApplicationController
 
   def bookmarks
     @q = current_user.bookmark_spots.ransack(params[:q])
-    query_result = @q.result(distinct: true).includes(:artist).order(created_at: :desc)
+    query_result = @q.result.includes(:artist).order(created_at: :desc)
     @bookmark_spots = query_result.page(params[:page])
     gon.spots = query_result
     gon.artists = Artist.all
@@ -82,7 +82,7 @@ class SpotsController < ApplicationController
   private
 
   def spot_params
-    params.require(:artist_spot).permit(:tag, :spot_name, :name, :detail, :address, :latitude, :longitude)
+    params.require(:artist_spot).permit(:tag, :spot_name, :name, :detail, :address, :latitude, :longitude, { images: [] }, :images_cache)
   end
 
   def set_spot

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -1,7 +1,7 @@
 class ArtistSpot
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
-  attr_accessor :id, :tag, :spot_name, :name, :detail, :address, :latitude, :longitude, :user_id
+  attr_accessor :id, :tag, :spot_name, :name, :detail, :address, :latitude, :longitude, :images, :images_cache, :user_id
 
   with_options presence: true do
     validates :tag
@@ -18,9 +18,9 @@ class ArtistSpot
       artist = Artist.find_or_create_by(name:)
       if id.present?
         spot = Spot.find(id)
-        spot.update(tag:, spot_name:, detail:, address:, latitude:, longitude:, artist_id: artist.id)
+        spot.update(tag:, spot_name:, detail:, address:, latitude:, longitude:, images:, artist_id: artist.id)
       else
-        Spot.create(tag:, spot_name:, detail:, address:, latitude:, longitude:, user_id:, artist_id: artist.id)
+        Spot.create(tag:, spot_name:, detail:, address:, latitude:, longitude:, images:, user_id:, artist_id: artist.id)
       end
     end
   end

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -11,6 +11,8 @@ class ArtistSpot
     validates :user_id
   end
 
+  validate :images_count_validation
+
   def save
     return if invalid?
 
@@ -23,5 +25,12 @@ class ArtistSpot
         Spot.create(tag:, spot_name:, detail:, address:, latitude:, longitude:, images:, user_id:, artist_id: artist.id)
       end
     end
+  end
+
+  private
+
+  def images_count_validation
+    valid_images = images.compact_blank
+    errors.add(:images, :too_many) if valid_images.size > 4
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,4 +1,6 @@
 class Spot < ApplicationRecord
+  mount_uploaders :images, ImageUploader
+
   belongs_to :user
   belongs_to :artist
   has_many :bookmarks, dependent: :destroy

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,51 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,7 +1,8 @@
 class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+  process resize_to_fill: [600, 400, 'Center']
 
   # Choose what kind of storage to use for this uploader:
   # storage :file

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -2,7 +2,10 @@
   <%= render "shared/error_messages", object: form.object %>
 
   <div class="mb-6">
-    <%= form.label :tag, class: "text-base font-bold mb-2" %>
+    <div class="flex flex-wrap">
+      <%= form.label :tag, class: "text-base font-bold mb-2" %>
+      <p class="text-red-500 ml-1">*</p>
+    </div>
 
     <div class="flex justify-around">
       <div>
@@ -23,12 +26,18 @@
   </div>
 
   <div class="mb-6">
-    <%= form.label :spot_name, class: "text-base font-bold mb-2" %>
+    <div class="flex flex-wrap">
+      <%= form.label :spot_name, class: "text-base font-bold mb-2" %>
+      <p class="text-red-500 ml-1">*</p>
+    </div>
     <%= form.text_field :spot_name, placeholder: t(".spot_name_placeholder"), id: "spot", class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
   </div>
 
   <div class="mb-6">
-    <%= form.label :name, class: "text-base font-bold mb-2" %>
+    <div class="flex flex-wrap">
+      <%= form.label :name, class: "text-base font-bold mb-2" %>
+      <p class="text-red-500 ml-1">*</p>
+    </div>
     <%= form.text_field :name, placeholder: t(".artist_name_placeholder"), class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
   </div>
 
@@ -38,14 +47,20 @@
   </div>
 
   <div class="mb-6">
-    <%= form.label :images, class: "text-base font-bold mb-2" %>
+    <div class="flex flex-wrap">
+      <%= form.label :images, class: "text-base font-bold mb-2" %>
+      <p class="ml-1 text-sm"><%= t(".images_limit") %></p>
+    </div>
     <%= form.file_field :images, multiple: true, accept: "image/*", class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
     <%= form.hidden_field :images_cache %>
   </div>
 
   <div class="flex flex-wrap justify-between items-end mb-2 w-full">
     <div class="flex flex-col flex-grow">
-      <%= form.label :address, class: "text-base font-bold mb-2" %>
+      <div class="flex flex-wrap">
+        <%= form.label :address, class: "text-base font-bold mb-2" %>
+        <p class="text-red-500 ml-1">*</p>
+      </div>
       <%= form.text_field :address, placeholder: t(".address_placeholder"), id: "address", class: "shadow appearance-none border rounded py-2 px-3 mr-2 leading-tight" %>
     </div>
     <div class="flex flex-nowrap">

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -37,6 +37,12 @@
     <%= form.text_field :detail, class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
   </div>
 
+  <div class="mb-6">
+    <%= form.label :images, class: "text-base font-bold mb-2" %>
+    <%= form.file_field :images, multiple: true, accept: "image/*", class: "shadow appearance-none border rounded w-full py-2 px-3 leading-tight" %>
+    <%= form.hidden_field :images_cache %>
+  </div>
+
   <div class="flex flex-wrap justify-between items-end mb-2 w-full">
     <div class="flex flex-col flex-grow">
       <%= form.label :address, class: "text-base font-bold mb-2" %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -10,8 +10,24 @@
     <% end %>
   </div>
 
-  <% @spot.images.each do |spot| %>
-    <%= image_tag (spot.url) %>
+  <% if @spot.images.present? %>
+    <div class="flex justify-center mb-10">
+      <div class="carousel custom-carousel overflow-hidden rounded-lg shadow hover:shadow-lg transition duration-300">
+        <% @spot.images.each_with_index do |spot, i| %>
+          <div id="slide<%= i + 1 %>" class="carousel-item relative">
+            <%= image_tag (spot.url), class: "object-cover w-full h-full" %>
+            <% if @spot.images.size >= 2 %>
+              <div class="absolute flex justify-between transform -translate-y-1/2 left-2 right-2 top-1/2">
+                <% prev_index = i > 0 ? i : @spot.images.size %>
+                <% next_index = i + 2 <= @spot.images.size ? i + 2 : 1 %>
+                <a href="#slide<%= prev_index %>" class="btn btn-circle">❮</a>
+                <a href="#slide<%= next_index %>" class="btn btn-circle">❯</a>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
   <% end %>
 
   <div class="flex justify-center mb-10">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -10,6 +10,10 @@
     <% end %>
   </div>
 
+  <% @spot.images.each do |spot| %>
+    <%= image_tag (spot.url) %>
+  <% end %>
+
   <div class="flex justify-center mb-10">
     <table class="table-fixed w-10/12">
       <tr class="h-10">

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -19,7 +19,7 @@ ja:
         spot_name: "地名 / 施設名"
         detail: "詳細"
         tag: "聖地分類"
-        address: "住所"
+        address: "所在地"
         latitude: "緯度"
         longitude: "経度"
       comment:
@@ -33,7 +33,8 @@ ja:
         spot_name: "地名 / 施設名"
         tag: "聖地分類"
         detail: "詳細"
-        address: "住所"
+        address: "所在地"
+        images: "写真"
   enums:
     spot:
       tag:

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -35,6 +35,12 @@ ja:
         detail: "詳細"
         address: "所在地"
         images: "写真"
+    errors:
+      models:
+        artist_spot:
+          attributes:
+            images:
+              too_many: "の数が多すぎます（最大4枚）"
   enums:
     spot:
       tag:
@@ -47,10 +53,10 @@ ja:
       alert: "会員登録に失敗しました"
   user_sessions:
     create:
-      notice: ログインしました
-      alert: ログインに失敗しました
+      notice: "ログインしました"
+      alert: "ログインに失敗しました"
     destroy:
-      notice: ログアウトしました
+      notice: "ログアウトしました"
   spots:
     create:
       notice: "聖地を作成しました"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -47,6 +47,7 @@ ja:
     form:
       spot_name_placeholder: "こちらに入力した状態で「マーカー作成」ボタンをクリックすると自動で住所が入力されます"
       artist_name_placeholder: "正確なアーティスト名を入力してください"
+      images_limit: "（４枚まで投稿できます）"
       address_placeholder: "マーカーを作成、ドラッグすると自動で更新されます"
       create_marker: "マーカー作成"
       delete_marker: "マーカー削除"

--- a/db/migrate/20240121023845_add_images_to_spots.rb
+++ b/db/migrate/20240121023845_add_images_to_spots.rb
@@ -1,0 +1,5 @@
+class AddImagesToSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :spots, :images, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_15_131945) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_21_023845) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_15_131945) do
     t.string "address", null: false
     t.float "latitude"
     t.float "longitude"
+    t.json "images"
     t.index ["artist_id"], name: "index_spots_on_artist_id"
     t.index ["user_id"], name: "index_spots_on_user_id"
   end


### PR DESCRIPTION
聖地作成、編集時に写真を４枚まで投稿できる機能を実装しました。

## 概要
写真投稿機能を実装するにあたりActive Storageも検討しましたが、`_cache`メソッドが使用できないということでCarrierWaveを導入しました。
現状、バリデーションエラー時にフォームに画像が入っていない状態になってしまっていますが、一度保留にして他を進めようと思います。

以下に今回の実装のポイントをまとめます。
- 画像加工には`gem "mini_magick"`を導入
- 詳細ページにはdaisyUIのカルーセルを導入
- 投稿できる写真の枚数はカスタムバリデーションで４枚に制限
