### PR TITLE
add: 投稿、編集画面におけるアーティスト名のオートコンプリート

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -36,15 +36,10 @@ class SpotsController < ApplicationController
 
   def create
     @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
-    if check_artist_name
-      if @artist_spot.save
-        redirect_to spots_path, data: { turbo: false }, notice: t('.notice')
-      else
-        flash.now[:alert] = t('.alert')
-        render :new, status: :unprocessable_entity
-      end
+    if @artist_spot.save
+      redirect_to spots_path, data: { turbo: false }, notice: t('.notice')
     else
-      flash.now[:alert] = t('.name')
+      flash.now[:alert] = t('.alert')
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -6,7 +6,6 @@ class ArtistSpot
   with_options presence: true do
     validates :tag
     validates :spot_name
-    validates :name
     validates :address
     validates :user_id
   end
@@ -37,10 +36,16 @@ class ArtistSpot
 
   # 「Spotify API上のデータと比較することで正確なアーティスト名が入力されているかチェックするバリデーション
   def check_artist_name
-    spotify_data = RSpotify::Artist.search(name).first
-    errors.add(:name, :no_artist_data) unless spotify_data
+    if name.blank?
+      errors.add(:name, :input_artist_name)
+    else
+      spotify_data = RSpotify::Artist.search(name).first
+      errors.add(:name, :no_artist_data) unless spotify_data
 
-    spotify_name = spotify_data.name
-    errors.add(:name, :not_accurate_name) unless name == spotify_name
+      if spotify_data
+        spotify_name = spotify_data.name
+        errors.add(:name, :not_accurate_name) unless name == spotify_name
+      end
+    end
   end
 end

--- a/app/javascript/_form.js
+++ b/app/javascript/_form.js
@@ -14,7 +14,7 @@ function initMap(){
 }
 
 
-// 「マーカー作成」ボタンクリック時に実行される関数
+// 「取得」ボタンクリック時に実行される関数
 function createMarker(){
   let inputAddress = document.getElementById('spot').value;
 
@@ -44,7 +44,7 @@ function createMarker(){
 }
 
 
-// 「マーカー削除」ボタンをクリックした際に実行される関数
+// 「リセット」ボタンをクリックした際に実行される関数
 function deleteMaker(){
   if (marker) {
     marker.setMap(null);

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -26,10 +26,10 @@ document.addEventListener("turbo:load", () => {
     listTab.classList.remove("tab-active");
   });
 
-  listView.style.display = "block";
-  mapView.style.display = "none";
-  listTab.classList.add("tab-active");
-  mapTab.classList.remove("tab-active");
+  mapView.style.display = "block";
+  listView.style.display = "none";
+  mapTab.classList.add("tab-active");
+  listTab.classList.remove("tab-active");
 });
 
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <%= image_tag "cat.svg", class: "ml-20" %>
-<footer class="text-neutral-50 bg-yellow-400 py-3">
+<footer class="text-neutral-50 bg-yellow-400 py-6">
   <div class="flex-col md:flex-row items-center">
     <nav class="flex justify-center text-base space-x-3">
       <%= link_to t("defaults.terms_of_service"), terms_of_service_path, class: "link-primary" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,6 @@
   <div class="flex flex-wrap p-5 flex-col md:flex-row items-center">
     <%= link_to "Music Map", root_path, class: "flex items-center text-4xl text-neutral-50 mb-4 md:mb-0" %>
     <nav class="md:ml-auto flex flex-wrap items-center text-xl justify-center">
-      <%= link_to t("defaults.spots_index"), spots_path, data: { turbo: false }, class: "mr-5 link-primary" %>
       <details class="dropdown dropdown-end">
         <summary class="btn border-0 shadow-none bg-yellow-400 text-neutral-50 hover:bg-amber-500 hover:shadow-md">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
@@ -10,6 +9,7 @@
           </svg>
         </summary>
         <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52 text-gray-700">
+          <li><%= link_to t("defaults.spots_index"), spots_path, data: { turbo: false } %></li>
           <li><%= link_to t("defaults.bookmarks_index"), bookmarks_spots_path, data: { turbo: false } %></li>
           <li><%= link_to t("defaults.profile"), profile_path %></li>
           <li><%= link_to t("defaults.logout"), logout_path, data: { turbo_method: :delete } %></li>

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -1,3 +1,0 @@
-<div class="my-6">
-  <div id="map" class="h-[36rem] rounded-md"></div>
-</div>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -30,7 +30,10 @@
       <%= form.label :name, class: "text-base font-bold mb-2" %>
       <p class="text-red-500 ml-1">*</p>
     </div>
-    <%= form.text_field :name, placeholder: t(".artist_name_placeholder"), class: "shadow border rounded w-full py-2 px-3" %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="/spots/autocomplete" role="combobox" class="flex-auto relative">
+      <%= form.text_field :name, placeholder: t(".artist_name_placeholder"), class: "shadow border rounded w-full py-2 px-3", data: { autocomplete_target: 'input' } %>
+      <ul class="list-group flex-auto absolute z-10 w-full rounded-md shadow bg-white" data-autocomplete-target="results"></ul>
+    </div>
   </div>
 
   <div class="flex justify-between items-end mb-10 w-full">

--- a/app/views/spots/_map.html.erb
+++ b/app/views/spots/_map.html.erb
@@ -1,0 +1,3 @@
+<div class="my-6">
+  <div id="map" class="h-[40rem] rounded-md"></div>
+</div>

--- a/app/views/spots/_tab_list.html.erb
+++ b/app/views/spots/_tab_list.html.erb
@@ -1,4 +1,4 @@
 <div role="tablist" class="tabs tabs-bordered mb-2">
-  <a role="tab" id="list-tab" class="tab"><%= t("defaults.display_list") %></a>
   <a role="tab" id="map-tab" class="tab"><%= t("defaults.display_map") %></a>
+  <a role="tab" id="list-tab" class="tab"><%= t("defaults.display_list") %></a>
 </div>

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -10,7 +10,7 @@
       <%= render "search_form", q: @q, url: bookmarks_spots_path %>
     </div>
   </div>
-  <%= render "shared/tab_list" %>
+  <%= render "tab_list" %>
 
   <div id="list-view">
     <div class="my-6">
@@ -30,7 +30,7 @@
     </div>
   </div>
   <div id="map-view">
-    <%= render "shared/map" %>
+    <%= render "map" %>
   </div>
 </div>
 

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <%= render "shared/tab_list" %>
+  <%= render "tab_list" %>
 
   <div id="list-view">
     <div class="my-6">
@@ -34,7 +34,7 @@
     </div>
   </div>
   <div id="map-view">
-    <%= render "shared/map" %>
+    <%= render "map" %>
   </div>
 </div>
 

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -67,7 +67,7 @@
       <% end %>
     </div>
 
-  <div class="flex items-center justify-end mr-2 mb-20">
+  <div class="flex items-center justify-end mr-2 mb-16">
     <% if logged_in? && current_user.own?(@spot) %>
       <%= link_to t(".spot_edit"), edit_spot_path(@spot), data: { turbo: false }, class: "btn-primary" %>
     <% end %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -45,7 +45,7 @@
   <% unless logged_in? %>
   <div class="flex justify-center mt-10 mb-20">
     <div class="flex flex-col">
-      <h2 class="text-2xl font-base mb-3">登録はこちら</h2>
+      <h2 class="text-xl font-base mb-3">登録はこちらから</h2>
       <div class="flex justify-center">
         <%= link_to t("defaults.signup"), new_user_path, class: "btn-primary" %>
       </div>

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -40,6 +40,7 @@ ja:
         artist_spot:
           attributes:
             name:
+              input_artist_name: "を入力してください"
               no_artist_data: "が正しく取得できませんでした"
               not_accurate_name: "が正確ではありません"
             images:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -10,7 +10,7 @@ ja:
     inquiry: "お問い合わせ"
     signup: "会員登録"
     spot_create: "聖地作成"
-    create: "作成"
+    create: "登録"
     edit: "編集"
     delete: "削除"
     search: "検索"


### PR DESCRIPTION
聖地投稿、編集画面でアーティスト名のオートコンプリート機能を実装しました。

## 概要
### オートコンプリート
Stimulus Autocompleteを導入してアーティスト名のオートコンプリートを実装しました。
[参考サイト](https://github.com/afcapel/stimulus-autocomplete?tab=readme-ov-file)

## その他
- tab_list、mapパーシャルを配置するフォルダを変更しました
- 一部デザインを調整しました
- jsファイルのコメントを修正しました