### PR TITLE
update: 聖地詳細画面における画像表示方法の変更

### DIFF
--- a/app/javascript/controllers/slideshow_controller.js
+++ b/app/javascript/controllers/slideshow_controller.js
@@ -7,8 +7,6 @@ export default class extends Controller {
   initialize() {
     this.index = 0
     this.showCurrentSlide()
-    console.log(this.countValue)
-    console.log(typeof this.countValue)
   }
 
   next() {

--- a/app/javascript/controllers/slideshow_controller.js
+++ b/app/javascript/controllers/slideshow_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "slide" ]
+  static values = { count: Number }
+
+  initialize() {
+    this.index = 0
+    this.showCurrentSlide()
+    console.log(this.countValue)
+    console.log(typeof this.countValue)
+  }
+
+  next() {
+    if (this.index >= this.countValue - 1) {
+      this.index = 0
+      this.showCurrentSlide()
+    }else{
+      this.index++
+      this.showCurrentSlide()
+    }
+  }
+
+  previous() {
+    if (this.index <= 0) {
+      this.index = this.countValue - 1
+      this.showCurrentSlide()
+    }else{
+      this.index--
+      this.showCurrentSlide()
+    }
+  }
+
+  showCurrentSlide() {
+    this.slideTargets.forEach((element, index) => {
+      element.hidden = index !== this.index
+    })
+  }
+}

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -6,26 +6,6 @@
   </div>
 
   <div class="mx-auto">
-    <% if @spot.images.present? %>
-      <div class="flex justify-center mb-10">
-        <div class="overflow-hidden rounded-lg shadow hover:shadow-lg transition duration-300" data-controller="slideshow" data-slideshow-count-value=<%= @spot.images.size %>>
-          <% @spot.images.each do |spot| %>
-            <div class="relative">
-              <div data-slideshow-target="slide">
-                <%= image_tag (spot.url), class: "object-cover w-full h-full" %>
-                <% if @spot.images.size >= 2 %>
-                  <div class="absolute flex justify-between w-full transform -translate-y-1/2 top-1/2">
-                    <button class="btn btn-circle opacity-70" data-action="slideshow#previous">❮</button>
-                    <button class="btn btn-circle opacity-70" data-action="slideshow#next">❯</button>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-
     <div class="px-18">
       <div class="mb-4">
         <div class="flex flex-wrap items-center mb-2">
@@ -39,6 +19,33 @@
         <p><%= simple_format(@spot.detail) %></p>
       </section>
     </div>
+
+    <% if @spot.images.present? %>
+      <div class="flex flex-row mb-10">
+          <div class="overflow-hidden shrink-0 rounded-lg shadow hover:shadow-lg transition duration-300" data-controller="slideshow" data-slideshow-count-value=<%= @spot.images.size %>>
+            <% @spot.images.each do |spot| %>
+              <div class="relative">
+                <div data-slideshow-target="slide">
+                  <%= image_tag (spot.url) %>
+                  <% if @spot.images.size >= 2 %>
+                    <div class="absolute flex justify-between w-full transform -translate-y-1/2 top-1/2">
+                      <button class="btn btn-circle opacity-70" data-action="slideshow#previous">❮</button>
+                      <button class="btn btn-circle opacity-70" data-action="slideshow#next">❯</button>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <div class="flex flex-col justify-center shrink">
+          <% @spot.images.each do |spot| %>
+            <div data-slideshow-target="slide">
+              <%= image_tag (spot.url), class: "rounded m-2 w-30 h-20 hover:shadow-2xl transition duration-300" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
 
     <div class="mb-8 px-18">
       <div class="mb-2">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -22,26 +22,24 @@
 
     <% if @spot.images.present? %>
       <div class="flex flex-row mb-10">
-          <div class="overflow-hidden shrink-0 rounded-lg shadow hover:shadow-lg transition duration-300" data-controller="slideshow" data-slideshow-count-value=<%= @spot.images.size %>>
-            <% @spot.images.each do |spot| %>
-              <div class="relative">
-                <div data-slideshow-target="slide">
-                  <%= image_tag (spot.url) %>
-                  <% if @spot.images.size >= 2 %>
-                    <div class="absolute flex justify-between w-full transform -translate-y-1/2 top-1/2">
-                      <button class="btn btn-circle opacity-70" data-action="slideshow#previous">❮</button>
-                      <button class="btn btn-circle opacity-70" data-action="slideshow#next">❯</button>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        <div class="flex flex-col justify-center shrink">
+        <div class="overflow-hidden shrink-0 rounded-lg shadow hover:shadow-lg transition duration-300" data-controller="slideshow" data-slideshow-count-value="<%= @spot.images.size %>">
           <% @spot.images.each do |spot| %>
-            <div data-slideshow-target="slide">
-              <%= image_tag (spot.url), class: "rounded m-2 w-30 h-20 hover:shadow-2xl transition duration-300" %>
+            <div class="relative">
+              <div data-slideshow-target="slide">
+                <%= image_tag (spot.url) %>
+                <% if @spot.images.size >= 2 %>
+                  <div class="absolute flex justify-between w-full transform -translate-y-1/2 top-1/2">
+                    <button class="btn btn-circle opacity-70" data-action="slideshow#previous">❮</button>
+                    <button class="btn btn-circle opacity-70" data-action="slideshow#next">❯</button>
+                  </div>
+                <% end %>
+              </div>
             </div>
+          <% end %>
+        </div>
+        <div class="flex flex-col justify-center shrink">
+          <% @spot.images.each_with_index do |spot, i| %>
+            <%= image_tag (spot.url), class: "rounded m-2 w-30 h-20 hover:shadow-2xl transition duration-300", data: {index: i} %>
           <% end %>
         </div>
       </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -8,18 +8,18 @@
   <div class="mx-auto">
     <% if @spot.images.present? %>
       <div class="flex justify-center mb-10">
-        <div class="carousel custom-carousel overflow-hidden rounded-lg shadow hover:shadow-lg transition duration-300">
-          <% @spot.images.each_with_index do |spot, i| %>
-            <div id="slide<%= i + 1 %>" class="carousel-item relative">
-              <%= image_tag (spot.url), class: "object-cover w-full h-full" %>
-              <% if @spot.images.size >= 2 %>
-                <div class="absolute flex justify-between transform -translate-y-1/2 left-2 right-2 top-1/2">
-                  <% prev_index = i > 0 ? i : @spot.images.size %>
-                  <% next_index = i + 2 <= @spot.images.size ? i + 2 : 1 %>
-                  <a href="#slide<%= prev_index %>" class="btn btn-circle">❮</a>
-                  <a href="#slide<%= next_index %>" class="btn btn-circle">❯</a>
-                </div>
-              <% end %>
+        <div class="overflow-hidden rounded-lg shadow hover:shadow-lg transition duration-300" data-controller="slideshow" data-slideshow-count-value=<%= @spot.images.size %>>
+          <% @spot.images.each do |spot| %>
+            <div class="relative">
+              <div data-slideshow-target="slide">
+                <%= image_tag (spot.url), class: "object-cover w-full h-full" %>
+                <% if @spot.images.size >= 2 %>
+                  <div class="absolute flex justify-between w-full transform -translate-y-1/2 top-1/2">
+                    <button class="btn btn-circle opacity-70" data-action="slideshow#previous">❮</button>
+                    <button class="btn btn-circle opacity-70" data-action="slideshow#next">❯</button>
+                  </div>
+                <% end %>
+              </div>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
聖地詳細画面における画像表示について一部変更しました。

## 概要
- 画像スライド時に画面が上部に移動してしまうためdaisyUIからstimulusに変更しました。
- 画像横に添付されている写真のサムネイルを表示することで何枚画像が添付されているか分かるように変更しました。

## その他
今回は上手く実装できませんでしたが、後日サムネイルをクリックした際に表示される画像が切り替わるように変更予定です。