### PR TITLE
add: 聖地削除機能の実装

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -37,7 +37,7 @@ class SpotsController < ApplicationController
   def create
     @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id))
     if @artist_spot.save
-      redirect_to spots_path, data: { turbo: false }, notice: t('.notice')
+      redirect_to spots_path, notice: t('.notice')
     else
       flash.now[:alert] = t('.alert')
       render :new, status: :unprocessable_entity
@@ -47,11 +47,17 @@ class SpotsController < ApplicationController
   def update
     @artist_spot = ArtistSpot.new(spot_params.merge(user_id: current_user.id, id: params[:id]))
     if @artist_spot.save
-      redirect_to spot_path(@artist_spot.id), data: { turbo: false }, notice: t('.notice')
+      redirect_to spot_path(@artist_spot.id), notice: t('.notice')
     else
       flash.now[:alert] = t('.alert')
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    spot = current_user.spots.find(params[:id])
+    spot.destroy!
+    redirect_to spots_path, notice: t('.notice'), status: :see_other
   end
 
   def bookmarks

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -20,17 +20,17 @@ class SpotsController < ApplicationController
   end
 
   def edit
-    @spot = current_user.spots.find(params[:id])
+    spot = current_user.spots.find(params[:id])
     @artist_spot = ArtistSpot.new(
-      id: @spot.id,
-      tag: @spot.tag,
-      spot_name: @spot.spot_name,
-      name: @spot.artist.name,
-      detail: @spot.detail,
-      user_id: @spot.user_id,
-      address: @spot.address,
-      latitude: @spot.latitude,
-      longitude: @spot.longitude
+      id: spot.id,
+      tag: spot.tag,
+      spot_name: spot.spot_name,
+      name: spot.artist.name,
+      detail: spot.detail,
+      user_id: spot.user_id,
+      address: spot.address,
+      latitude: spot.latitude,
+      longitude: spot.longitude
     )
   end
 

--- a/app/javascript/show.js
+++ b/app/javascript/show.js
@@ -16,5 +16,19 @@ function initMap(){
   });
 }
 
-// initMap関数をグローバルにするための記述
+
+// 聖地削除時に確認ダイアログを表示するための関数
+function checkDelete(){
+  if(window.confirm("本当に削除しますか？")){
+    return true;
+  }
+  else{
+    window.alert("キャンセルされました");
+    return false;
+  }
+}
+
+
+// 関数をグローバルにするための記述
 window.initMap = initMap;
+window.checkDelete = checkDelete;

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @artist_spot, url: @artist_spot.id ? spot_path(@artist_spot.id) : spots_path, method: (@artist_spot.id ? :patch : :post), local: true do |form| %>
+<%= form_with model: artist_spot, url: artist_spot.id ? spot_path(artist_spot.id) : spots_path, method: (artist_spot.id ? :patch : :post), local: true do |form| %>
   <%= render "shared/error_messages", object: form.object %>
 
   <div class="mb-10">

--- a/app/views/spots/_search_form.html.erb
+++ b/app/views/spots/_search_form.html.erb
@@ -6,6 +6,6 @@
       <%= form.hidden_field :artist_name, data: { autocomplete_target: 'hidden' } %>
       <ul class="list-group flex-auto absolute z-10 w-full rounded-md shadow bg-white" data-autocomplete-target="results"></ul>
     </div>
-    <%= form.button t("defaults.search"), class: "btn-secondary ml-2", type: "button", onclick: "submit();" %>
+    <%= form.button t("defaults.search"), class: "btn-secondary ml-1", type: "button", onclick: "submit();" %>
   <% end %>
 </div>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -5,6 +5,6 @@
     <hr>
   </div>
 
-  <%= render 'form', spot: @spot %>
+  <%= render "form", artist_spot: @artist_spot %>
 
 </div>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -5,6 +5,6 @@
     <hr>
   </div>
 
-  <%= render 'form', spot: @artist_spot %>
+  <%= render "form",  artist_spot: @artist_spot %>
 
 </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -72,11 +72,12 @@
       <% end %>
     </div>
 
-  <div class="flex items-center justify-end mr-2 mb-16">
-    <% if logged_in? && current_user.own?(@spot) %>
-      <%= link_to t(".spot_edit"), edit_spot_path(@spot), data: { turbo: false }, class: "btn-primary" %>
-    <% end %>
-  </div>
+    <div class="flex items-center justify-end mr-2 mb-16">
+      <% if logged_in? && current_user.own?(@spot) %>
+        <%= link_to t("defaults.edit"), edit_spot_path(@spot), data: { turbo: false }, class: "btn-primary mr-2" %>
+        <%= button_to t("defaults.delete"), spot_path(@spot), method: :delete, data: { turbo: false }, form: { onSubmit: "return checkDelete()" }, class: "btn-primary text-gray-700 bg-gray-100 hover:bg-red-600 hover:text-neutral-50 hover:shadow-md" %>
+      <% end %>
+    </div>
 
     <div class="mb-8">
       <hr>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -20,7 +20,9 @@
 <section class="flex justify-center my-4 p-4">
   <div class="flex flex-col w-3/4 rounded-xl shadow-md">
     <h2 class="flex justify-center text-3xl font-medium">Music Mapとは？</h2>
-    <p class="flex justify-center py-4">音楽に関する聖地を登録、検索できるお出かけアプリです♪<br>皆さんの知ってる聖地を自由に登録してみましょう！</p></div>
+    <p class="flex justify-center pt-4">音楽に関する聖地を登録、検索できるお出かけアプリです♪</p>
+    <p class="flex justify-center pb-4">皆さんの知ってる聖地を自由に登録してみましょう！</p>
+  </div>
 </section>
 
 <section class="flex justify-center my-4 p-4">
@@ -30,7 +32,7 @@
       <section class="m-4">
         <h3 class="flex justify-center text-2xl font-medium">その１. 聖地を登録してみよう！</h3>
         <p class="flex justify-center pt-4">好きなアーティストに関連する場所を登録してみましょう♪</p>
-        <p class="flex justify-center pb-4">登録フォームではマップ上のマーカーをドラッグすることで詳細な位置を登録できるよ！</p>
+        <p class="flex justify-center pb-4">登録フォームではマップ上のマーカーをドラッグすることで詳細な位置を登録できます！</p>
       </section>
       <section class="m-4">
         <h3 class="flex justify-center text-2xl font-medium">その２. 聖地を検索してみよう！</h3>

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -68,6 +68,8 @@ ja:
     update:
       notice: "聖地を更新しました"
       alert: "聖地の更新に失敗しました"
+    destroy:
+      notice: "聖地を削除しました"
   comments:
     create:
       notice: "コメントを作成しました"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -31,7 +31,6 @@ ja:
   spots:
     show:
       title: "聖地詳細"
-      spot_edit: "聖地編集"
       spot_name: "地名 / 施設名"
       spot_tag: "分類"
       artist_name: "アーティスト名"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root "static_pages#top"
 
   resources :users, only: %i[new create]
-  resources :spots, except: %i[destroy] do
+  resources :spots do
     resources :comments, only: %i[create destroy], shallow: true
     collection do
       get :bookmarks


### PR DESCRIPTION
聖地を作成したユーザーが自分が登録した聖地を削除する機能を実装しました。

## 概要
以下のサイトを参考に削除機能を実装しました。
- [button_to・button_tag・link_toの違いとturbo](https://abillyz.com/moco/studies/612)
- [Rails7 button_toでdata: { turbo: false }でも確認ダイアログを表示させる](https://qiita.com/mt-blue-sou/items/24fb796fffecdb812237)