### PR TITLE
update: バリデーションの修正、追加

### DIFF
--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -11,6 +11,8 @@ class ArtistSpot
     validates :user_id
   end
 
+  validates :spot_name, length: { maximum: 30 }
+
   validate :images_count_validation
   validate :check_artist_name
 

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -7,6 +7,7 @@ class ArtistSpot
     validates :tag
     validates :spot_name
     validates :address
+    validates :detail
     validates :user_id
   end
 

--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -42,13 +42,10 @@ class ArtistSpot
     if name.blank?
       errors.add(:name, :input_artist_name)
     else
-      spotify_data = RSpotify::Artist.search(name).first
+      spotify_data = RSpotify::Artist.search(name).map(&:name)
       errors.add(:name, :no_artist_data) unless spotify_data
 
-      if spotify_data
-        spotify_name = spotify_data.name
-        errors.add(:name, :not_accurate_name) unless name == spotify_name
-      end
+      errors.add(:name, :not_accurate_name) if spotify_data&.exclude?(name)
     end
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -6,8 +6,8 @@ class Spot < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  validates :spot_name, presence: true, length: { maximum: 255 }
-  validates :detail, length: { maximum: 65_535 }
+  validates :spot_name, presence: true, length: { maximum: 30 }
+  validates :detail, presence: true, length: { maximum: 65_535 }
   validates :tag, presence: true
 
   enum tag: { video_location: 0, sign: 1, others: 2 }

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -4,7 +4,7 @@
 
     <div class="mb-6">
       <%= form.label :body, class: "text-base font-bold mb-2" %>
-      <%= form.text_field :body, class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
+      <%= form.text_field :body, required: true, class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
     </div>
 
     <div class="flex items-center justify-center mb-10">

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -41,6 +41,7 @@
       <div class="flex flex-wrap">
         <%= form.label :spot_name, class: "text-base font-bold mb-2" %>
         <p class="text-red-500 ml-1">*</p>
+        <p class="ml-1 text-sm"><%= t(".spot_name_limit") %></p>
       </div>
       <%= form.text_field :spot_name, placeholder: t(".spot_name_placeholder"), id: "spot", class: "shadow border rounded w-full py-2 px-3" %>
     </div>

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -71,7 +71,10 @@
   </div>
 
   <div class="mb-10">
-    <%= form.label :detail, class: "text-base font-bold mb-2" %>
+    <div class="flex flex-wrap">
+      <%= form.label :detail, class: "text-base font-bold mb-2" %>
+      <p class="text-red-500 ml-1">*</p>
+    </div>
     <%= form.text_area :detail, rows: 4, class: "shadow appearance-none border rounded w-full py-2 px-3 mb-3 leading-tight" %>
   </div>
 

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -66,7 +66,9 @@
         </div>
       </div>
       <div class="flex items-center mr-2">
+        <% if logged_in? %>
           <%= render_bookmark_button(current_user, @spot) %>
+        <% end %>
         <% if logged_in? && current_user.own?(@spot) %>
           <%= link_to "https://twitter.com/share?url=%0a#{request.url}&text=MusicMap%0a#{@spot.spot_name}/#{@spot.artist.name}", target: "_blank", title: "Xでシェア" do %>
             <i><%= image_tag "logo-white.png", class: "w-8 rounded-lg bg-black p-2 m-2" %></i>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -21,7 +21,7 @@
   <div class="flex flex-col w-3/4 rounded-xl shadow-md bg-neutral-100 py-6">
     <h2 class="flex justify-center text-3xl font-medium">Music Mapとは？</h2>
     <p class="flex justify-center pt-4">音楽に関する聖地を登録、検索できるお出かけアプリです♪</p>
-    <p class="flex justify-center">皆さんの知ってる聖地を自由に登録してみましょう！</p>
+    <p class="flex justify-center">音楽と出会い、街の新しい魅力を発見しましょう！</p>
   </div>
 </section>
 

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -19,7 +19,7 @@ ja:
         spot_name: "地名 / 施設名"
         detail: "詳細"
         tag: "分類"
-        address: "所在地"
+        address: "住所"
         latitude: "緯度"
         longitude: "経度"
       comment:
@@ -33,7 +33,7 @@ ja:
         spot_name: "地名 / 施設名"
         tag: "分類"
         detail: "詳細"
-        address: "所在地"
+        address: "住所"
         images: "写真"
     errors:
       models:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -45,6 +45,7 @@ ja:
       title: "聖地編集"
     form:
       artist_name_placeholder: "正確なアーティスト名を入力してください"
+      spot_name_limit: "（30文字以内）"
       spot_name_placeholder: "「取得」ボタンをクリックすると所在地を取得できます"
       address_message: "（マーカーをドラッグすることで微調整ができます）"
       address_placeholder: "国外は正しく取得できない場合があります。必要に応じて修正してください"

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -36,7 +36,7 @@ ja:
       artist_name: "アーティスト名"
       detail: "詳細"
       create_user: "作成者"
-      address: "所在地"
+      address: "住所"
       to_spot_index: "一覧へ戻る"
       none_comment: "コメントがありません"
     index:
@@ -46,10 +46,10 @@ ja:
     form:
       artist_name_placeholder: "正確なアーティスト名を入力してください"
       spot_name_limit: "（30文字以内）"
-      spot_name_placeholder: "「取得」ボタンをクリックすると所在地を取得できます"
+      spot_name_placeholder: "ボタンをクリックすると住所を取得できます"
       address_message: "（マーカーをドラッグすることで微調整ができます）"
       address_placeholder: "国外は正しく取得できない場合があります。必要に応じて修正してください"
-      create_marker: "取得"
+      create_marker: "住所取得"
       delete_marker: "リセット"
       images_limit: "（４枚まで投稿できます）"
     bookmarks:

--- a/db/migrate/20240207130832_change_cloumns_notnull_add_spots.rb
+++ b/db/migrate/20240207130832_change_cloumns_notnull_add_spots.rb
@@ -1,0 +1,5 @@
+class ChangeCloumnsNotnullAddSpots < ActiveRecord::Migration[7.1]
+  def change
+    change_column :spots, :detail, :text, null: false
+  end
+end

--- a/db/migrate/20240207133202_change_cloumns_notnull_add_comments.rb
+++ b/db/migrate/20240207133202_change_cloumns_notnull_add_comments.rb
@@ -1,0 +1,5 @@
+class ChangeCloumnsNotnullAddComments < ActiveRecord::Migration[7.1]
+  def change
+    change_column :comments, :body, :string, null: false
+  end
+end

--- a/db/migrate/20240207142654_change_cloumns_limit_add_spot_name.rb
+++ b/db/migrate/20240207142654_change_cloumns_limit_add_spot_name.rb
@@ -1,0 +1,5 @@
+class ChangeCloumnsLimitAddSpotName < ActiveRecord::Migration[7.1]
+  def change
+    change_column :spots, :spot_name, :string, limit: 30, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_07_133202) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_07_142654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,7 +41,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_07_133202) do
   end
 
   create_table "spots", force: :cascade do |t|
-    t.string "spot_name", null: false
+    t.string "spot_name", limit: 30, null: false
     t.text "detail", null: false
     t.integer "tag", null: false
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_07_130832) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_07_133202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_07_130832) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.string "body"
+    t.string "body", null: false
     t.bigint "user_id", null: false
     t.bigint "spot_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_21_023845) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_07_130832) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_21_023845) do
 
   create_table "spots", force: :cascade do |t|
     t.string "spot_name", null: false
-    t.text "detail"
+    t.text "detail", null: false
     t.integer "tag", null: false
     t.bigint "user_id", null: false
     t.bigint "artist_id", null: false


### PR DESCRIPTION
バリデーションを修正、追加しました。
また、バグを修正しました。

## 概要
### バリデーション関連
次の制約を追加しました。
- spotsテーブルのdetailにnull:false制約を追加
- 地名/施設名を30文字以内に制限
- カスタムバリデーションのバグ修正

### バグ修正
- 未ログイン状態で聖地詳細画面を表示できないバグを修正しました。
- 空のコメント送信時に発生するバグを修正しました。