### PR TITLE
fix: ログアウト時に検索機能のオートコンプリート表示がおかしくなるのを修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,5 +1,5 @@
 class SpotsController < ApplicationController
-  skip_before_action :require_login, only: %i[index show]
+  skip_before_action :require_login, only: %i[index show autocomplete]
 
   def index
     @q = Spot.ransack(params[:q])


### PR DESCRIPTION
ログアウト状態で検索機能を利用した際にオートコンプリート表示がおかしくなるのを修正しました。