### PR TITLE
update: 一覧画面の聖地登録ボタンの廃止

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t(".title")) %>
-<div class="container mx-auto min-h-[600px] sm:sm:min-h-screen px-8">
+<div class="container mx-auto min-h-[600px] sm:sm:min-h-screen px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t(".title") %></h1>
     <hr>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("defaults.profile")) %>
-<div class="container mx-auto min-h-[600px] sm:min-h-screen px-8">
+<div class="container mx-auto min-h-[600px] sm:min-h-screen px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.profile") %></h1>
     <hr>

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("defaults.bookmarks_index")) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-4">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.bookmarks_index") %></h1>
     <hr>

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -6,7 +6,7 @@
   </div>
 
   <div class="flex flex-wrap justify-between items-center w-full my-6">
-    <div class="flex flex-grow mb-1 mr-2 sm:mr-0">
+    <div class="flex flex-grow mb-1">
       <%= render "search_form", q: @q, url: bookmarks_spots_path %>
     </div>
   </div>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t(".title")) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t(".title") %></h1>
     <hr>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -6,11 +6,8 @@
   </div>
 
   <div class="flex flex-wrap justify-between items-center w-full my-6">
-    <div class="flex flex-grow mb-1 mr-2 lg:mr-3 sm:mr-0">
+    <div class="flex flex-grow mb-1">
       <%= render "search_form", q: @q, url: spots_path %>
-    </div>
-    <div class="mb-1 hidden lg:block">
-      <%= link_to t("defaults.spot_create"), new_spot_path, data: { turbo: false }, class: "btn-primary" %>
     </div>
   </div>
 

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("defaults.spots_index")) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-4">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.spots_index") %></h1>
     <hr>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("defaults.spot_create")) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.spot_create") %></h1>
     <hr>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, @spot.spot_name) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t(".title") %></h1>
     <hr>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <h1 class="text-2xl font-bold mb-2">プライバシーポリシー</h1>
     <p>MelodyMap（以下，「当社」といいます。）は，本ウェブサイト上で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。</p>
     <br>

--- a/app/views/static_pages/terms_of_service.html.erb
+++ b/app/views/static_pages/terms_of_service.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <h1 class="text-2xl font-bold mb-2">利用規約</h1>
     <p>この利用規約（以下，「本規約」といいます。）は，MelodyMap（以下，「当社」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>
     <br>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("defaults.login")) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.login") %></h1>
     <hr>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t("defaults.signup")) %>
-<div class="container mx-auto px-8">
+<div class="container mx-auto px-8 xl:px-28">
   <div class="mb-8">
     <h1 class="text-xl font-bold mb-2"><%= t("defaults.signup") %></h1>
     <hr>


### PR DESCRIPTION
### 概要
一覧画面で検索ボタンをクリックしようとした際に誤って聖地登録ボタンをクリックしてしまったという意見をユーザーから頂いたため聖地登録ボタンを一覧画面から取り除きました。
代わりにハンバーガーメニューに聖地登録ページへのリンクを配置しているためここから登録が可能になっています。

### その他
一部のレイアウトを微調整しました。