### PR TITLE
update: アプリを旅行体験寄りの作りにするため一部の文言を修正しました

### DIFF
--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -17,7 +17,7 @@ ja:
         name: "アーティスト名"
       spot:
         spot_name: "地名 / 施設名"
-        detail: "詳細"
+        detail: "思い出 / 詳細"
         tag: "分類"
         address: "住所"
         latitude: "緯度"
@@ -32,9 +32,9 @@ ja:
         name: "アーティスト名"
         spot_name: "地名 / 施設名"
         tag: "分類"
-        detail: "詳細"
+        detail: "思い出 / 詳細"
         address: "住所"
-        images: "写真"
+        images: "思い出の写真"
     errors:
       models:
         artist_spot:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -34,7 +34,7 @@ ja:
       spot_name: "地名 / 施設名"
       spot_tag: "分類"
       artist_name: "アーティスト名"
-      detail: "詳細"
+      detail: "思い出 / 詳細"
       create_user: "作成者"
       address: "住所"
       to_spot_index: "一覧へ戻る"


### PR DESCRIPTION
ユーザーが著作権に反した写真を投稿することを防止するためアプリの作りを旅行体験寄りにし、実際に訪れた際の写真を投稿するよう誘導しました。

以下変更ポイント

- 「写真」→「思い出の写真」
- 「詳細」→「思い出 / 詳細」
