### PR TITLE
fix: アーティスト名を判定するカスタムバリデーションの修正

### DIFF
--- a/app/forms/artist_spot.rb
+++ b/app/forms/artist_spot.rb
@@ -45,7 +45,16 @@ class ArtistSpot
       spotify_data = RSpotify::Artist.search(name).map(&:name)
       errors.add(:name, :no_artist_data) unless spotify_data
 
-      errors.add(:name, :not_accurate_name) if spotify_data&.exclude?(name)
+      japanese_artist = name.match?(/[一-龠]/)
+
+      formatted_name = name.delete(' ')
+      formatted_spotify_data = spotify_data.map { |n| n.delete(' ') }
+
+      if japanese_artist
+        errors.add(:name, :not_accurate_name) unless formatted_spotify_data.include?(formatted_name)
+      elsif spotify_data&.exclude?(name)
+        errors.add(:name, :not_accurate_name)
+      end
     end
   end
 end


### PR DESCRIPTION
日本人アーティストを登録する際にバリデーションにより弾かれてしまう場合があるバグを修正しました。

## 概要
本アプリではSpotify APIを利用してフォームに入力されたアーティスト名が正確であるか確認するカスタムバリデーションを導入しておりますが日本人アーティストの場合、苗字と名前の間に半角スペースが入るか入らないかの違いにより弾かれてしまうバグが発生しておりました。

例
- 星野源→弾かれる、星野 源→弾かれない
- 米津玄師→弾かれない、米津 玄師→弾かれる

この仕様の場合、ユーザー視点では何故弾かれてしまっているかの判断ができないため以下の基準に則り対応を行います。


### 基準

- アーティスト名に漢字が含まれている場合、日本人アーティストと判定し半角スペース有無による違いを見逃す

この場合、アーティスト名に漢字が含まれていると半角スペースの違いが無条件で無視されてしまうことから本来入るべきではない場所に半角スペースを入れることができてしまうという別の問題が発生してしまいますが、上記の問題の方が深刻であると考えこちらでの対応といたします。

別の問題の例
- Official髭男dismはアーティスト名のどこにでも半角スペースを入れることができてしまう。


### その他
漢字が含まれているかどうかの判定は以下のサイトを参考にしました。
[JavaScriptで漢字を表す正規表現  |  You Look Too Cool](https://stabucky.com/wp/archives/7594)
